### PR TITLE
Fix compilation with GCC v9.x

### DIFF
--- a/winsup/cygwin/exec.cc
+++ b/winsup/cygwin/exec.cc
@@ -81,11 +81,12 @@ execv (const char *path, char * const *argv)
 }
 
 extern "C" int
-execve (const char *path, char *const argv[], char *const envp[])
+execve_1 (const char *path, char *const argv[], char *const envp[])
 {
   return spawnve (_P_OVERLAY, path, argv, envp);
 }
-EXPORT_ALIAS (execve, _execve)	/* For newlib */
+EXPORT_ALIAS (execve_1, _execve)	/* For newlib */
+EXPORT_ALIAS (execve_1, execve)
 
 extern "C" int
 execvp (const char *file, char * const *argv)

--- a/winsup/cygwin/libc/bsdlib.cc
+++ b/winsup/cygwin/libc/bsdlib.cc
@@ -265,12 +265,12 @@ logwtmp (const char *line, const char *user, const char *host)
   ut.ut_type = USER_PROCESS;
   ut.ut_pid = getpid ();
   if (line)
-    strncpy (ut.ut_line, line, sizeof ut.ut_line);
+    strlcpy (ut.ut_line, line, sizeof ut.ut_line);
   time (&ut.ut_time);
   if (user)
-    strncpy (ut.ut_user, user, sizeof ut.ut_user);
+    strlcpy (ut.ut_user, user, sizeof ut.ut_user);
   if (host)
-    strncpy (ut.ut_host, host, sizeof ut.ut_host);
+    strlcpy (ut.ut_host, host, sizeof ut.ut_host);
   updwtmp (_PATH_WTMP, &ut);
 }
 

--- a/winsup/cygwin/posix_timer.cc
+++ b/winsup/cygwin/posix_timer.cc
@@ -81,7 +81,7 @@ timer_tracker::arm_overrun_event (LONG64 exp_cnt)
 LONG
 timer_tracker::disarm_overrun_event ()
 {
-  LONG ret;
+  LONG ret = 0;
 
   AcquireSRWLockExclusive (&srwlock);
   if (overrun_count != OVR_DISARMED)


### PR DESCRIPTION
I tried building the MSYS2 runtime recently and it failed because of the upgrade of `/usr/bin/gcc` to v9.x...