### PR TITLE
Last-minute fixes to prepare for v3.1.4

### DIFF
--- a/winsup/cygwin/fhandler_tty.cc
+++ b/winsup/cygwin/fhandler_tty.cc
@@ -3497,7 +3497,23 @@ fhandler_pty_master::setup_pseudoconsole ()
 			 TRUE, EXTENDED_STARTUPINFO_PRESENT,
 			 NULL, NULL, &si_helper.StartupInfo, &pi_helper))
       goto cleanup_event_and_pipes;
-    WaitForSingleObject (hello, INFINITE);
+    for (;;)
+      {
+        DWORD wait_result = WaitForSingleObject (hello, 500);
+	if (wait_result == WAIT_OBJECT_0)
+	  break;
+	if (wait_result != WAIT_TIMEOUT)
+	  goto cleanup_helper_process;
+	DWORD exit_code;
+	if (!GetExitCodeProcess(pi_helper.hProcess, &exit_code))
+	  goto cleanup_helper_process;
+	if (exit_code == STILL_ACTIVE)
+	  continue;
+	if (exit_code != 0 ||
+	    WaitForSingleObject (hello, 500) != WAIT_OBJECT_0)
+	  goto cleanup_helper_process;
+	break;
+      }
     CloseHandle (hello);
     CloseHandle (pi_helper.hThread);
     /* Retrieve pseudo console handles */

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2177,6 +2177,7 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
                  to the directory of the destination */
              {
                 /* Determine the character position of the last path component */
+                const char *newpath = win32_newpath.get_posix();
                 int pos = strlen (newpath);
                 while (--pos >= 0)
                   if (isdirsep (newpath[pos]))

--- a/winsup/utils/dumper.cc
+++ b/winsup/utils/dumper.cc
@@ -131,7 +131,7 @@ dumper::sane ()
 void
 print_section_name (bfd* abfd, asection* sect, PTR obj)
 {
-  deb_printf (" %s", bfd_get_section_name (abfd, sect));
+  deb_printf (" %s", bfd_section_name (sect));
 }
 
 void
@@ -712,9 +712,8 @@ dumper::prepare_core_dump ()
 
       if (p->type == pr_ent_module && status_section != NULL)
 	{
-	  if (!bfd_set_section_size (core_bfd,
-				     status_section,
-				     (bfd_get_section_size (status_section)
+	  if (!bfd_set_section_size (status_section,
+				     (bfd_section_size (status_section)
 				      + sect_size)))
 	    {
 	      bfd_perror ("resizing status section");
@@ -738,8 +737,8 @@ dumper::prepare_core_dump ()
 	  goto failed;
 	}
 
-      if (!bfd_set_section_flags (core_bfd, new_section, sect_flags) ||
-	  !bfd_set_section_size (core_bfd, new_section, sect_size))
+      if (!bfd_set_section_flags (new_section, sect_flags) ||
+	  !bfd_set_section_size (new_section, sect_size))
 	{
 	  bfd_perror ("setting section attributes");
 	  goto failed;
@@ -823,7 +822,7 @@ dumper::write_core_dump ()
       deb_printf ("writing section type=%u base=%p size=%p flags=%08x\n",
 		  p->type,
 		  p->section->vma,
-		  bfd_get_section_size (p->section),
+		  bfd_section_size (p->section),
 		  p->section->flags);
 
       switch (p->type)

--- a/winsup/utils/parse_pe.cc
+++ b/winsup/utils/parse_pe.cc
@@ -73,11 +73,11 @@ select_data_section (bfd * abfd, asection * sect, PTR obj)
   exclusion *excl_list = (exclusion *) obj;
 
   if ((sect->flags & (SEC_CODE | SEC_DEBUGGING)) &&
-      sect->vma && bfd_get_section_size (sect))
+      sect->vma && bfd_section_size (sect))
     {
-      excl_list->add ((LPBYTE) sect->vma, (SIZE_T) bfd_get_section_size (sect));
+      excl_list->add ((LPBYTE) sect->vma, (SIZE_T) bfd_section_size (sect));
       deb_printf ("excluding section: %20s %08lx\n", sect->name,
-		  bfd_get_section_size (sect));
+		  bfd_section_size (sect));
     }
 }
 

--- a/winsup/utils/strace.cc
+++ b/winsup/utils/strace.cc
@@ -351,7 +351,8 @@ create_child (char **argv)
     flags |= CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP;
 
   make_command_line (one_line, argv);
-  printf ("create_child: %s\n", one_line.buf);
+  if (!quiet)
+    printf ("create_child: %s\n", one_line.buf);
 
   SetConsoleCtrlHandler (NULL, 0);
 /* Commit message for this code was:


### PR DESCRIPTION
Turns out that my previous PR (#4) did not result in anything that compiles.

So here are two patches that fix the compilation (one because the `newpath` variable went away, the other because binutils were upgraded to a version that no longer supports some of the `bfd_*()` functions).

While at it, I also slipped in two more patches that I think are uncontroversial: one to make `strace --quiet` really quiet, and the other to fix the situation where an older `msys-2.0.dll` is overwritten with a freshly-built `msys0.dll` without also copying the new version of `cygwin-console-helper.exe` (which caused me quite some pain to figure out: MinTTY would simply hang and I needed several days to debug this).