### PR TITLE
Fix MSYS=wincmdln, and enable it by default

### DIFF
--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -68,7 +68,7 @@ bool allow_glob = true;
 bool ignore_case_with_glob;
 bool pipe_byte;
 bool reset_com;
-bool wincmdln;
+bool wincmdln = true;
 winsym_t allow_winsymlinks = WSYM_sysfile;
 bool disable_pcon = true;
 

--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -412,13 +412,13 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
 	          newargv.replace (i, tmpbuf);
 	          free (tmpbuf);
 	        }
-	      if ((wincmdln || !real_path.iscygexec ())
-	            && !cmd.fromargv (newargv, real_path.get_win32 (),
-			        real_path.iscygexec ()))
-	        {
-	          res = -1;
-	          __leave;
-	        }
+	    }
+	  if ((wincmdln || !real_path.iscygexec ())
+	        && !cmd.fromargv (newargv, real_path.get_win32 (),
+		    real_path.iscygexec ()))
+	    {
+	      res = -1;
+	      __leave;
 	    }
 
 

--- a/winsup/doc/cygwinenv.xml
+++ b/winsup/doc/cygwinenv.xml
@@ -68,7 +68,7 @@ time and when handles are inherited.  Defaults to set.</para>
 <listitem>
 <para><envar>(no)wincmdln</envar> - if set, the windows complete command
 line (truncated to ~32K) will be passed on any processes that it creates
-in addition to the normal UNIX argv list.  Defaults to not set.</para>
+in addition to the normal UNIX argv list.  Defaults to set.</para>
 </listitem>
 
 <listitem>


### PR DESCRIPTION
This is apparently broken since 2015...