### PR TITLE
Re-add 3.1.6 patches

### DIFF
--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -68,7 +68,7 @@ bool allow_glob = true;
 bool ignore_case_with_glob;
 bool pipe_byte;
 bool reset_com;
-bool wincmdln;
+bool wincmdln = true;
 winsym_t allow_winsymlinks = WSYM_sysfile;
 bool disable_pcon = true;
 

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1657,7 +1657,7 @@ static int
 recursiveCopy (char * src, char * dst, const char * origpath)
 {
   WIN32_FIND_DATA dHfile;
-  HANDLE dH;
+  HANDLE dH = INVALID_HANDLE_VALUE;
   BOOL findfiles;
   int srcpos = strlen (src);
   int dstpos = strlen (dst);
@@ -1726,6 +1726,9 @@ recursiveCopy (char * src, char * dst, const char * origpath)
   res = 0;
 
 done:
+
+  if (dH != INVALID_HANDLE_VALUE)
+    FindClose (dH);
 
   return res;
 }

--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -419,13 +419,13 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
 	          newargv.replace (i, tmpbuf);
 	          free (tmpbuf);
 	        }
-	      if ((wincmdln || !real_path.iscygexec ())
-	            && !cmd.fromargv (newargv, real_path.get_win32 (),
-			        real_path.iscygexec ()))
-	        {
-	          res = -1;
-	          __leave;
-	        }
+	    }
+	  if ((wincmdln || !real_path.iscygexec ())
+	        && !cmd.fromargv (newargv, real_path.get_win32 (),
+		    real_path.iscygexec ()))
+	    {
+	      res = -1;
+	      __leave;
 	    }
 
 

--- a/winsup/doc/cygwinenv.xml
+++ b/winsup/doc/cygwinenv.xml
@@ -72,7 +72,7 @@ time and when handles are inherited.  Defaults to set.</para>
 <listitem>
 <para><envar>(no)wincmdln</envar> - if set, the windows complete command
 line (truncated to ~32K) will be passed on any processes that it creates
-in addition to the normal UNIX argv list.  Defaults to not set.</para>
+in addition to the normal UNIX argv list.  Defaults to set.</para>
 </listitem>
 
 <listitem>


### PR DESCRIPTION
As pointed out by @jeremyd2019 in https://github.com/msys2/msys2-runtime/pull/11#issuecomment-678816280, a couple of patches from `msys2-3_1_6-release` did not make it into `msys2-3_1_7-release`.

This fixes that.