### PR TITLE
Fix encoding for console programs heeding `LC_ALL`

### DIFF
--- a/winsup/cygwin/fhandler_tty.cc
+++ b/winsup/cygwin/fhandler_tty.cc
@@ -2905,6 +2905,8 @@ fhandler_pty_slave::setup_locale (void)
 	  get_ttyp ()->term_code_page = cs_names[i].cp;
 	  break;
 	}
+  SetConsoleCP (get_ttyp ()->term_code_page);
+  SetConsoleOutputCP (get_ttyp ()->term_code_page);
 }
 
 void


### PR DESCRIPTION
Many console programs do not call `SetConsoleOutputCP()` to ensure that the expected code page is active, in particular programs with Linux roots (where you look at `LANG` and `LC_ALL` and `LC_CTYPE`, but not at a code page).

As of Cygwin v3.1.0 (and therefore, MSYS2 v3.1.x), this leads to garbled output, both with and without Pseudo Console support enabled.

Let's work around this.

This fixes https://github.com/msys2/MSYS2-packages/issues/1974