### PR TITLE
Expose the "deep-copy" symlink behavior via a new `winsymlinks` mode

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -87,6 +87,10 @@ set_winsymlinks (const char *buf)
   else if (ascii_strncasematch (buf, "native", 6))
     allow_winsymlinks = ascii_strcasematch (buf + 6, "strict")
 			? WSYM_nativestrict : WSYM_native;
+  else if (ascii_strncasematch (buf, "deepcopy", 8))
+    allow_winsymlinks = WSYM_deepcopy;
+  else
+    allow_winsymlinks = WSYM_sysfile;
 }
 
 /* The structure below is used to set up an array which is used to

--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -55,7 +55,8 @@ enum winsym_t
   WSYM_lnk,
   WSYM_native,
   WSYM_nativestrict,
-  WSYM_nfs
+  WSYM_nfs,
+  WSYM_deepcopy
 };
 
 exit_states NO_COPY exit_state;
@@ -69,7 +70,7 @@ bool ignore_case_with_glob;
 bool pipe_byte;
 bool reset_com;
 bool wincmdln = true;
-winsym_t allow_winsymlinks = WSYM_sysfile;
+winsym_t allow_winsymlinks = WSYM_deepcopy;
 bool disable_pcon = true;
 
 bool NO_COPY in_forkee;

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2269,73 +2269,76 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	}
       else
 	{
-      path_conv src_path;
-      src_path.check (oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
-      if (src_path.error)
-        {
-           set_errno (src_path.error);
-           __leave;
-        }
-      if (!src_path.isdevice () && !src_path.is_fs_special ())
-        {
-           /* MSYS copy file instead make symlink */
+          if (wsym_type == WSYM_deepcopy)
+	    {
+	      path_conv src_path;
+	      src_path.check (oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
+	      if (src_path.error)
+		{
+		  set_errno (src_path.error);
+		  __leave;
+		}
+	      if (!src_path.isdevice () && !src_path.is_fs_special ())
+	        {
+		  /* MSYS copy file instead make symlink */
 
-           char * real_oldpath;
-           if (isabspath (oldpath))
-             strcpy (real_oldpath = tp.c_get (), oldpath);
-           else
-              /* Find the real source path, relative
-                 to the directory of the destination */
-             {
-                /* Determine the character position of the last path component */
-                const char *newpath = win32_newpath.get_posix();
-                int pos = strlen (newpath);
-                while (--pos >= 0)
-                  if (isdirsep (newpath[pos]))
-                    break;
-                /* Append the source path to the directory
-                   component of the destination */
-                if (pos+1+strlen(oldpath) >= MAX_PATH)
-                  {
-                     set_errno(ENAMETOOLONG);
-                     __leave;
-                  }
-                strcpy (real_oldpath = tp.c_get (), newpath);
-                strcpy (&real_oldpath[pos+1], oldpath);
-             }
+		  char * real_oldpath;
+		  if (isabspath (oldpath))
+		    strcpy (real_oldpath = tp.c_get (), oldpath);
+		  else
+		    /* Find the real source path, relative
+		       to the directory of the destination */
+		    {
+		      /* Determine the character position of the last path component */
+		      const char *newpath = win32_newpath.get_posix();
+		      int pos = strlen (newpath);
+		      while (--pos >= 0)
+			if (isdirsep (newpath[pos]))
+			  break;
+		      /* Append the source path to the directory
+			 component of the destination */
+		      if (pos+1+strlen(oldpath) >= MAX_PATH)
+			{
+			  set_errno(ENAMETOOLONG);
+			  __leave;
+			}
+		      strcpy (real_oldpath = tp.c_get (), newpath);
+		      strcpy (&real_oldpath[pos+1], oldpath);
+		    }
 
-           /* As a MSYS limitation, the source path must exist. */
-		   path_conv win32_oldpath;
-           win32_oldpath.check (real_oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
-           if (!win32_oldpath.exists ())
-             {
-                set_errno (ENOENT);
-                __leave;
-             }
+		  /* As a MSYS limitation, the source path must exist. */
+		  path_conv win32_oldpath;
+		  win32_oldpath.check (real_oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
+		  if (!win32_oldpath.exists ())
+		    {
+		      set_errno (ENOENT);
+		      __leave;
+		    }
 
-           char *w_newpath;
-           char *w_oldpath;
-           stpcpy (w_newpath = tp.c_get (), win32_newpath.get_win32());
-           stpcpy (w_oldpath = tp.c_get (), win32_oldpath.get_win32());
-           if (win32_oldpath.isdir())
-             {
-                char *origpath;
-                strcpy (origpath = tp.c_get (), w_oldpath);
-                res = recursiveCopy (w_oldpath, w_newpath, origpath);
-             }
-           else
-             {
-                if (!CopyFile (w_oldpath, w_newpath, FALSE))
-                  {
-                     __seterrno ();
-                  }
-                else
-                  {
-                     res = 0;
-                  }
-             }
-           __leave;
-        }
+		  char *w_newpath;
+		  char *w_oldpath;
+		  stpcpy (w_newpath = tp.c_get (), win32_newpath.get_win32());
+		  stpcpy (w_oldpath = tp.c_get (), win32_oldpath.get_win32());
+		  if (win32_oldpath.isdir())
+		    {
+		      char *origpath;
+		      strcpy (origpath = tp.c_get (), w_oldpath);
+		      res = recursiveCopy (w_oldpath, w_newpath, origpath);
+		    }
+		  else
+		    {
+		      if (!CopyFile (w_oldpath, w_newpath, FALSE))
+			{
+			  __seterrno ();
+			}
+		      else
+			{
+			  res = 0;
+			}
+		    }
+		  __leave;
+		}
+	    }
 
 	  /* Default technique creating a symlink. */
 	  buf = tp.t_get ();

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1958,7 +1958,6 @@ typedef struct _REPARSE_LX_SYMLINK_BUFFER
   } LxSymlinkReparseBuffer;
 } REPARSE_LX_SYMLINK_BUFFER,*PREPARSE_LX_SYMLINK_BUFFER;
 
-#ifndef __MSYS__
 static int
 symlink_wsl (const char *oldpath, path_conv &win32_newpath)
 {
@@ -2029,7 +2028,6 @@ symlink_wsl (const char *oldpath, path_conv &win32_newpath)
   NtClose (fh);
   return 0;
 }
-#endif
 
 int
 symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
@@ -2114,7 +2112,6 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	    }
 	  /* Otherwise, fall back to default symlink type. */
 	  wsym_type = WSYM_sysfile;
-#ifndef __MSYS__
 	  fallthrough;
 	case WSYM_sysfile:
 	  if (win32_newpath.fs_flags () & FILE_SUPPORTS_REPARSE_POINTS)
@@ -2126,7 +2123,6 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	  /* On FSes not supporting reparse points, or in case of an error
 	     creating the WSL symlink, fall back to creating the plain old
 	     SYSTEM file symlink. */
-#endif
 	  break;
 	default:
 	  break;


### PR DESCRIPTION
In https://gitter.im/msys2/msys2?at=5f8fe84abbffc02b582d6915, @Alexpux lamented that `tar` does not extract symbolic links but makes deep copies instead.

The reason for this is that we specifically override Cygwin's `symlink()` behavior to make deep copies instead of creating a special-crafted system file that Cygwin (MSYS2, and only those two) will recognize as symbolic link.

The patch to override this behavior is incomplete, though: it hacks up the `WSYM_sysfile` code path, which causes all kinds of problems:

- Contrary to the documentation, `MSYS=winsymlinks:native` won't fall back to creating Cygwin-style symbolic links. Instead, it (quite surprisingly) creates deep copies instead.
- There is no way to opt into the original Cygwin behavior because that code path is now dead code.
- The fact that the `WSYM_sysfile` code path is modified to do something very different from what it is intended to do means that all changes that Cygwin makes to that code path have to be inspected, and occasionally even more hacks have to be put on top, such as https://github.com/msys2/msys2-runtime/commit/44bb1334481a2d7c84588c413f5cace86b8f6e6c, where we specifically had to disable Cygwin's code to try creating WSL symlinks before falling back to creating system files instead).

Let's fix this by introducing a proper new mode: `MSYS=winsymlinks:deepcopy`. This mode is made the default so that users should be unaffected by this PR.

Users wishing to let the MSYS2 runtime create Cygwin-style symbolic links can ask for that by setting `MSYS=winsymlinks:sysfile`.

By fixing this issue, we can now stop disabling Cygwin's WSL symlink behavior, too: it is in the `sysfile` code path and won't affect the default behavior of the MSYS2 runtime.

While at it, the indentation of the original patch is fixed, too.