### PR TITLE
Cherry-pick gcc 10 fixes

### DIFF
--- a/winsup/cygwin/fhandler_console.cc
+++ b/winsup/cygwin/fhandler_console.cc
@@ -2765,7 +2765,7 @@ fhandler_console::write_normal (const unsigned char *src,
   DWORD done;
   DWORD buf_len;
   const unsigned char *found = src;
-  size_t ret;
+  int ret;
   mbstate_t ps;
   mbtowc_p f_mbtowc;
 
@@ -2945,7 +2945,7 @@ do_print:
 		{
 		  ret = __utf8_mbtowc (_REENT, NULL, (const char *) found + 1,
 				       end - found - 1, &ps);
-		  if (ret != (size_t) -1)
+		  if (ret != -1)
 		    while (ret-- > 0)
 		      {
 			WCHAR w = *(found + 1);

--- a/winsup/cygwin/fhandler_socket_inet.cc
+++ b/winsup/cygwin/fhandler_socket_inet.cc
@@ -1378,7 +1378,7 @@ fhandler_socket_wsock::send_internal (struct _WSAMSG *wsamsg, int flags)
      buffer which only gets partially written. */
   for (DWORD in_idx = 0, in_off = 0;
        in_idx < wsamsg->dwBufferCount;
-       in_off >= wsamsg->lpBuffers[in_idx].len && (++in_idx, in_off = 0))
+       in_off >= wsamsg->lpBuffers[in_idx].len && (++in_idx, (in_off = 0)))
     {
       /* Split a message into the least number of pieces to minimize the
 	 number of WsaSendTo calls.  Don't split datagram messages (bad idea).

--- a/winsup/cygwin/ntdll.h
+++ b/winsup/cygwin/ntdll.h
@@ -18,7 +18,7 @@ extern GUID __cygwin_socket_guid;
 /* Custom Cygwin-only status codes. */
 #define STATUS_THREAD_SIGNALED	((NTSTATUS)0xe0000001)
 #define STATUS_THREAD_CANCELED	((NTSTATUS)0xe0000002)
-#define STATUS_ILLEGAL_DLL_PSEUDO_RELOCATION ((NTSTATUS) 0xe0000269)
+#define STATUS_ILLEGAL_DLL_PSEUDO_RELOCATION ((DWORD) 0xe0000269)
 
 /* Simplify checking for a transactional error code. */
 #define NT_TRANSACTIONAL_ERROR(s)	\

--- a/winsup/cygwin/pseudo-reloc.cc
+++ b/winsup/cygwin/pseudo-reloc.cc
@@ -21,8 +21,6 @@
 #else
 # include "winsup.h"
 # include <sys/cygwin.h>
-/* custom status code: */
-# define STATUS_ILLEGAL_DLL_PSEUDO_RELOCATION ((NTSTATUS) 0xe0000269)
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
I tried to build msys2-runtime today, and ran into some errors with GCC 10, which have been fixed upstream.

git cherry-pick 3bb579a 129c984 c5bdf60