### PR TITLE
bug fix: ldd silent about missing dll dependencies

### DIFF
--- a/winsup/utils/ldd.cc
+++ b/winsup/utils/ldd.cc
@@ -407,6 +407,13 @@ report (const char *in_fn, bool multiple)
 	  }
 	  break;
 	case EXIT_PROCESS_DEBUG_EVENT:
+    if (ev.u.ExitProcess.dwExitCode != 0)
+    {
+      /* All dll dependencies were NOT found. */
+      process_fn = fn_win;
+      res = 1;
+    }
+
 print_and_exit:
 	  print_dlls (&dll_list, isdll ? fn_win : NULL, process_fn);
 	  exitnow = true;

--- a/winsup/utils/ldd.cc
+++ b/winsup/utils/ldd.cc
@@ -123,6 +123,19 @@ static struct filelist
   char *name;
 } *head;
 
+static void
+destroy_filelist (struct filelist **phead)
+{
+  struct filelist *next, *head = *phead;
+  while (head) {
+    next = head->next;
+    free (head->name);
+    free (head);
+    head = next;
+  }
+  *phead = NULL;
+}
+
 static bool
 saw_file (char *name)
 {
@@ -248,6 +261,18 @@ struct dlls
     struct dlls *next;
   };
 
+static void
+destroy_dlls (struct dlls *dlls)
+{
+  struct dlls* next;
+  while (dlls) {
+    next = dlls->next;
+    free (dlls);
+    dlls = next;
+  }
+
+}
+
 #define SLOP strlen (" (?)")
 char *
 tocyg (wchar_t *win_fn)
@@ -280,7 +305,7 @@ tocyg (wchar_t *win_fn)
 static int
 print_dlls (dlls *dll, const wchar_t *dllfn, const wchar_t *process_fn)
 {
-  head = NULL;			/* FIXME: memory leak */
+  destroy_filelist(&head);
   while ((dll = dll->next))
     {
       char *fn;
@@ -429,6 +454,9 @@ print_and_exit:
       if (exitnow)
 	break;
     }
+
+  /* cleanup */
+  destroy_dlls(dll_list.next);
 
   return res;
 }


### PR DESCRIPTION
As of now `ldd` is silent about missing dll dependencies - and it always returns with `0`, regardless if all dll dependencies are found or not.

With the commits kept as minimal as possible, the PR fixes:
* missing dll dependencies are now listed marked with `not found` (dll dependencies on a dll which is not found are still not listed, of course)
* `ldd` returns with exit code `1` if not all dll dependencies are found.
* memory leakage as an extra

This bug is a bit painful per se - and, in particular, for the CI function `list_dll_deps` in `ci-library.sh` of the MSYS and MINGW repos:
~~~sh
# from ci-library.sh
# List DDL dependencies
list_dll_deps(){
    local target="${1}"
    echo "$(tput setaf 2)MSYS2 DLL dependencies:$(tput sgr0)"
    find "$target" -regex ".*\.\(exe\|dll\)" -print0 | xargs -0 -r ldd | GREP_COLOR="1;35" grep --color=always "msys-.*\|" \
    || echo "        None"
}
~~~
1. `list_dll_deps` could be amended, e.g.,
* for coloring and
*  such that CI fails or sends out an email if a dll dependency cannot be resolved (e.g., due to a changed dll file name)
2. The bug persists on `Cygwin`.  In case one of you guys think this should be patched upstream, please go ahead.  I am not really involved with the cygwin infrastructure I must admit.  Thanks.

I hope this PR sits on the correct branch of the repo. This is my first PR here.