### PR TITLE
Fix msys library name in import libraries

### DIFF
--- a/winsup/cygwin/speclib
+++ b/winsup/cygwin/speclib
@@ -37,6 +37,7 @@ while (<$nm_fd>) {
     study;
     if (/ I _?(.*)_dll_iname/o) {
 	$dllname = $1;
+	$dllname =~ s/_2_0/-2.0/;
     } else {
 	my ($file, $member, $symbol) = m%^([^:]*):([^:]*(?=:))?.* T (.*)%o;
 	next if !defined($symbol) || $symbol =~ $exclude_regex;


### PR DESCRIPTION
Cygwin's speclib doesn't handle dashes or dots. So we specifically fix up all the import libraries that link against `msys_2_0.dll` to correctly link against `msys-2.0.dll`. Closes #26.