### PR TITLE
uname: limit sysname to "MSYS" or "MINGW"

### DIFF
--- a/winsup/cygwin/uname.cc
+++ b/winsup/cygwin/uname.cc
@@ -37,9 +37,11 @@ uname_x (struct utsname *name)
       memset (name, 0, sizeof (*name));
       /* sysname */
       char* msystem = getenv("MSYSTEM");
-      const char *msystem_msys = "MSYS";
+      const char* msystem_sysname = "MSYS";
+      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
+        msystem_sysname = "MINGW";
       __small_sprintf (name->sysname, "%s_%s-%u%s",
-		       msystem ? msystem : msystem_msys,
+		       msystem_sysname,
 		       wincap.osname (), wincap.build_number (),
 		       wincap.is_wow64 () ? "-WOW64" : "");
       /* nodename */
@@ -103,8 +105,10 @@ uname (struct utsname *in_name)
       memset (name, 0, sizeof (*name));
 #ifdef __MSYS__
       char* msystem = getenv("MSYSTEM");
-      const char *msystem_msys = "MSYS";
-      __small_sprintf (name->sysname, "%s_%s", msystem ? msystem : msystem_msys, wincap.osname ());
+      const char* msystem_sysname = "MSYS";
+      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
+        msystem_sysname = "MINGW";
+      __small_sprintf (name->sysname, "%s_%s", msystem_sysname, wincap.osname ());
 #else
       __small_sprintf (name->sysname, "CYGWIN_%s", wincap.osname ());
 #endif


### PR DESCRIPTION
uname just included the content of the MSYSTEM env var as sysname
which leads to problems in case build tools use it detect a mingw build
and MSYSTEM is something like UCRT or CLANG.

To work around that, in case MSYSTEM is not set, empty, or not MSYS, then
we just output a hardcoded "MINGW".