### PR TITLE
Turn off default Windows error reporting by default

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -126,6 +126,7 @@ static struct parse_thing
   {"winsymlinks", {func: set_winsymlinks}, isfunc, NULL, {{0}, {0}}},
   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
+  {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
   {NULL, {0}, setdword, 0, {{0}, {0}}}
 };
 

--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -72,6 +72,7 @@ bool reset_com;
 bool wincmdln = true;
 winsym_t allow_winsymlinks = WSYM_deepcopy;
 bool disable_pcon = true;
+bool winjitdebug = false;
 
 bool NO_COPY in_forkee;
 

--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -462,7 +462,7 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
 	 get the default error mode instead of inheriting the mode Cygwin
 	 uses.  This allows things like Windows Error Reporting/JIT debugging
 	 to work with processes launched from a Cygwin shell. */
-      if (!real_path.iscygexec ())
+      if (winjitdebug && !real_path.iscygexec ())
 	c_flags |= CREATE_DEFAULT_ERROR_MODE;
 
       /* We're adding the CREATE_BREAKAWAY_FROM_JOB flag here to workaround


### PR DESCRIPTION
As reported in https://github.com/msys2/MSYS2-packages/pull/2414#issuecomment-810841296, v3.2.0 of the Cygwin runtime has a pretty disruptive new behavior where it shows a message box e.g. when a DLL is missing (it used to write that error message to `stderr` instead).

Let's reinstate the old behavior, allowing to opt-in to the new behavior (which is desired e.g. when debugging using a registered JIT debugger) via the `winjitdebug` flag in the environment variable `MSYS`.

This implements what we talked about [here](https://github.com/msys2/msys2-runtime/pull/18#issuecomment-724880792), at long last.

Cc: @lazka @jeremyd2019