### PR TITLE
make new native inner symlink code respect PC_SYM_FOLLOW and PC_SYM_NOFOLLOW_REP flags, and add option to disable it

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -127,6 +127,7 @@ static struct parse_thing
   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
   {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
+  {"nativeinnerlinks", {&nativeinnerlinks}, setbool, NULL, {{false}, {true}}},
   {NULL, {0}, setdword, 0, {{0}, {0}}}
 };
 

--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -75,6 +75,7 @@ bool wincmdln = true;
 winsym_t allow_winsymlinks = WSYM_deepcopy;
 bool disable_pcon = true;
 bool winjitdebug = false;
+bool nativeinnerlinks = true;
 
 bool NO_COPY in_forkee;
 

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3665,9 +3665,14 @@ restart:
 
 		     subst X: C:\foo\bar
 
-		   Treat it as a normal file. */
+		   Treat it like a symlink.  This is required to tell an
+		   lstat caller that the "drive" is actually pointing
+		   somewhere else, thus, it's a symlink in POSIX speak. */
 		if (upath.Length == 14)	/* \??\X:\ */
-		  goto file_not_symlink;
+		  {
+		    fileattr &= ~FILE_ATTRIBUTE_DIRECTORY;
+		    path_flags |= PATH_SYMLINK;
+		  }
 		/* For final paths differing in inner path components return
 		   length as negative value.  This informs path_conv::check
 		   to skip realpath handling on the last path component. */

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -723,9 +723,10 @@ path_conv::check (const char *src, unsigned opt,
 	  int symlen = 0;
 
 	  /* Make sure to check certain flags on last component only. */
-	  for (unsigned pc_flags = opt & (PC_NO_ACCESS_CHECK | PC_KEEP_HANDLE);
+	  for (unsigned pc_flags = opt & (PC_NO_ACCESS_CHECK | PC_KEEP_HANDLE
+					 | PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP);
 	       ;
-	       pc_flags = 0)
+	       pc_flags = opt & (PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP))
 	    {
 	      const suffix_info *suff;
 	      char *full_path;
@@ -3640,48 +3641,49 @@ restart:
 	    goto file_not_symlink;
 	}
 #endif /* __i386__ */
-      {
-	PWCHAR fpbuf = tp.w_get ();
-	DWORD ret;
+      if ((pc_flags & (PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP)) == PC_SYM_FOLLOW)
+	{
+	  PWCHAR fpbuf = tp.w_get ();
+	  DWORD ret;
 
-	ret = GetFinalPathNameByHandleW (h, fpbuf, NT_MAX_PATH, 0);
-	if (ret)
-	  {
-	    UNICODE_STRING fpath;
+	  ret = GetFinalPathNameByHandleW (h, fpbuf, NT_MAX_PATH, 0);
+	  if (ret)
+	    {
+	      UNICODE_STRING fpath;
 
-	    RtlInitCountedUnicodeString (&fpath, fpbuf, ret * sizeof (WCHAR));
-	    fpbuf[1] = L'?';	/* \\?\ --> \??\ */
-	    if (!RtlEqualUnicodeString (&upath, &fpath, !!ci_flag))
-	      {
-		issymlink = true;
-		/* upath.Buffer is big enough and unused from this point on.
-		   Reuse it here, avoiding yet another buffer allocation. */
-		char *nfpath = (char *) upath.Buffer;
-		sys_wcstombs (nfpath, NT_MAX_PATH, fpbuf);
-		res = posixify (nfpath);
+	      RtlInitCountedUnicodeString (&fpath, fpbuf, ret * sizeof (WCHAR));
+	      fpbuf[1] = L'?';	/* \\?\ --> \??\ */
+	      if (!RtlEqualUnicodeString (&upath, &fpath, !!ci_flag))
+	        {
+		  issymlink = true;
+		  /* upath.Buffer is big enough and unused from this point on.
+		     Reuse it here, avoiding yet another buffer allocation. */
+		  char *nfpath = (char *) upath.Buffer;
+		  sys_wcstombs (nfpath, NT_MAX_PATH, fpbuf);
+		  res = posixify (nfpath);
 
-		/* If the incoming path consisted of a drive prefix only,
-		   we just handle a virtual drive, created with, e.g.
+		  /* If the incoming path consisted of a drive prefix only,
+		     we just handle a virtual drive, created with, e.g.
 
-		     subst X: C:\foo\bar
+		       subst X: C:\foo\bar
 
-		   Treat it like a symlink.  This is required to tell an
-		   lstat caller that the "drive" is actually pointing
-		   somewhere else, thus, it's a symlink in POSIX speak. */
-		if (upath.Length == 14)	/* \??\X:\ */
-		  {
-		    fileattr &= ~FILE_ATTRIBUTE_DIRECTORY;
-		    path_flags |= PATH_SYMLINK;
-		  }
-		/* For final paths differing in inner path components return
-		   length as negative value.  This informs path_conv::check
-		   to skip realpath handling on the last path component. */
-		else
-		  res = -res;
-		break;
-	      }
-	  }
-      }
+		     Treat it like a symlink.  This is required to tell an
+		     lstat caller that the "drive" is actually pointing
+		     somewhere else, thus, it's a symlink in POSIX speak. */
+		  if (upath.Length == 14)	/* \??\X:\ */
+		    {
+		      fileattr &= ~FILE_ATTRIBUTE_DIRECTORY;
+		      path_flags |= PATH_SYMLINK;
+		    }
+		  /* For final paths differing in inner path components return
+		     length as negative value.  This informs path_conv::check
+		     to skip realpath handling on the last path component. */
+		  else
+		    res = -res;
+		  break;
+	        }
+	    }
+	}
 
     /* Normal file. */
     file_not_symlink:

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3641,7 +3641,8 @@ restart:
 	    goto file_not_symlink;
 	}
 #endif /* __i386__ */
-      if ((pc_flags & (PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP)) == PC_SYM_FOLLOW)
+      if (nativeinnerlinks
+	  && (pc_flags & (PC_SYM_FOLLOW | PC_SYM_NOFOLLOW_REP)) == PC_SYM_FOLLOW)
 	{
 	  PWCHAR fpbuf = tp.w_get ();
 	  DWORD ret;


### PR DESCRIPTION
I've cherry-picked the commits that made it upstream, plus added an option "nativeinnerlinks" which is on by default but can disable this new code for cases where it causes problems (most likely with SUBST and mapped network drives), by setting `MSYS=nonativeinnerlinks`.  This patch, and the option, fixes #41.