### PR TITLE
Don't fall back to ExitProcess if process handled Ctrl-C event

### DIFF
--- a/winsup/cygwin/include/cygwin/exit_process.h
+++ b/winsup/cygwin/include/cygwin/exit_process.h
@@ -163,10 +163,12 @@ exit_process (HANDLE process, int exit_code)
     {
     case SIGINT:
     case SIGQUIT:
+      /* We are not going to kill them but simply say that Ctrl+C
+      is pressed. If the processes want they can exit or else
+      just wait.*/
       if (kill_via_console_helper (
               process, L"CtrlRoutine",
-              signo == SIGINT ? CTRL_C_EVENT : CTRL_BREAK_EVENT, pid) &&
-          GetExitCodeProcess(process, &code) && code != STILL_ACTIVE)
+              signo == SIGINT ? CTRL_C_EVENT : CTRL_BREAK_EVENT, pid))
         return 0;
       /* fall-through */
     case SIGTERM:


### PR DESCRIPTION
I have experimented with the mysterious kernel32!CtrlRoutine that
it returns 0 if the CtrlHandlers set using SetConsoleCtrlHandler
handled it correctly. So, now rather than defaulting to move to
ExitProcess if the process isn't killed by CtrlRoutine, it will
check only if the ctrl event is handled correctly and falls
back to ExitProcess only when CtrlRoutine fails.

This should possibly allow python interactive mode.

Fixes https://github.com/msys2/msys2-runtime/issues/49

/cc @dscho @jeremyd2019 