### PR TITLE
Cygwin: disable inner symlink handling in msys2.

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3604,6 +3604,7 @@ restart:
 	    break;
 	}
 
+#ifndef __MSYS__
       /* Check if the inner path components contain native symlinks or
 	 junctions, or if the drive is a virtual drive.  Compare incoming
 	 path with path returned by GetFinalPathNameByHandleA.  If they
@@ -3677,6 +3678,7 @@ restart:
 	      }
 	  }
       }
+#endif
 
     /* Normal file. */
     file_not_symlink:


### PR DESCRIPTION
This code has had several issues related to subst and mapped network drives, so disable it for now.

Fixes #41