### PR TITLE
reinstate hardlink faking

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -93,6 +93,19 @@ set_winsymlinks (const char *buf)
     allow_winsymlinks = WSYM_sysfile;
 }
 
+static void
+set_fakehardlinks (const char *buf)
+{
+  if (!buf || !*buf)
+    fake_hardlinks = FHARD_ondemand;
+  else if (ascii_strncasematch (buf, "never", 5))
+    fake_hardlinks = FHARD_never;
+  else if (ascii_strncasematch (buf, "always", 6))
+    fake_hardlinks = FHARD_always;
+  else
+    fake_hardlinks = FHARD_ondemand;
+}
+
 /* The structure below is used to set up an array which is used to
    parse the CYGWIN environment variable or, if enabled, options from
    the registry.  */
@@ -124,6 +137,7 @@ static struct parse_thing
   {"reset_com", {&reset_com}, setbool, NULL, {{false}, {true}}},
   {"wincmdln", {&wincmdln}, setbool, NULL, {{false}, {true}}},
   {"winsymlinks", {func: set_winsymlinks}, isfunc, NULL, {{0}, {0}}},
+  {"fakehardlinks", {func: set_fakehardlinks}, isfunc, NULL, {{0}, {0}}},
   {"disable_pcon", {&disable_pcon}, setbool, NULL, {{false}, {true}}},
   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
   {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},

--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -61,6 +61,14 @@ enum winsym_t
   WSYM_deepcopy
 };
 
+/* Should hardlinks be faked.  The value is set depending on the
+   "fakehardlinks" setting of the CYGWIN environment variable. */
+enum fakehard_t {
+  FHARD_never = 0,
+  FHARD_ondemand,
+  FHARD_always
+};
+
 exit_states NO_COPY exit_state;
 
 /* Set in init.cc.  Used to check if Cygwin DLL is dynamically loaded. */
@@ -73,6 +81,7 @@ bool pipe_byte;
 bool reset_com;
 bool wincmdln = true;
 winsym_t allow_winsymlinks = WSYM_deepcopy;
+fakehard_t fake_hardlinks = FHARD_ondemand;
 bool disable_pcon = true;
 bool winjitdebug = false;
 bool nativeinnerlinks = true;


### PR DESCRIPTION
cygwin had hardlink faking removed with commit 6cabe044dd07c17bea043d924f414d74086df7b9. As opposed to what cygwin does, we allow symlink faking. I'm not seeing a concrete reason that we should not allow that for hardlinks. It would allow msys2 to be used on FAT-family volumes.

Instead of reverting the commit, I simply make it does what symlink_worker() does, i.e. use CopyFile() instead of CopyFileW() and do not call SetFileAttributesW().

Also introduces an environment variable to make hardlink faking always/never occur.

P.S. I haven't run any test on this yet, but please do let me know if I have done anything inappropriate.