### PR TITLE
kill: avoid using a potentially uninitialized value

### DIFF
--- a/winsup/utils/kill.cc
+++ b/winsup/utils/kill.cc
@@ -199,7 +199,7 @@ forcekill (pid_t pid, DWORD winpid, int sig, int wait)
         CloseHandle(h);
         h = h2;
       }
-      exit_process_tree (h2, 128 + sig);
+      exit_process_tree (h, 128 + sig);
     }
   CloseHandle (h);
 }


### PR DESCRIPTION
This clear bug was pointed out by @jeremyd2019 in the PR to upgrade to Cygwin v3.3.2: https://github.com/msys2/msys2-runtime/pull/63/files/950533d95e26b54e2e1ab26d4f5e65ce0c3f7305#r745004385