### PR TITLE
 Route "Device Status Report" responses correctly

### DIFF
--- a/winsup/cygwin/fhandler_tty.cc
+++ b/winsup/cygwin/fhandler_tty.cc
@@ -1153,7 +1153,11 @@ fhandler_pty_slave::reset_switch_to_pcon (void)
 		    {
 		      char pipe[MAX_PATH];
 		      __small_sprintf (pipe,
+#ifdef __MSYS__
+			       "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
+#else
 			       "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
+#endif
 			       &cygheap->installation_key, get_minor ());
 		      pipe_request req = { GetCurrentProcessId () };
 		      pipe_reply repl;
@@ -3738,7 +3742,11 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
     {
       char pipe[MAX_PATH];
       __small_sprintf (pipe,
+#ifdef __MSYS__
+		       "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
+#else
 		       "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
+#endif
 		       &cygheap->installation_key, ttyp->get_minor ());
       pipe_request req = { GetCurrentProcessId () };
       pipe_reply repl;

--- a/winsup/cygwin/fhandler_tty.cc
+++ b/winsup/cygwin/fhandler_tty.cc
@@ -1247,10 +1247,13 @@ fhandler_pty_slave::mask_switch_to_pcon_in (bool mask, bool xfer)
   else if (InterlockedDecrement (&num_reader) == 0)
     CloseHandle (slave_reading);
 
+  bool need_xfer =
+    get_ttyp ()->switch_to_pcon_in && !get_ttyp ()->pcon_activated;
+
   /* In GDB, transfer input based on setpgid() does not work because
      GDB may not set terminal process group properly. Therefore,
      transfer input here if isHybrid is set. */
-  if (isHybrid && !!masked != mask && xfer
+  if ((isHybrid || need_xfer) && !!masked != mask && xfer
       && GetStdHandle (STD_INPUT_HANDLE) == get_handle ())
     {
       if (mask && get_ttyp ()->pcon_input_state_eq (tty::to_nat))
@@ -1544,7 +1547,7 @@ out:
   if (ptr0)
     { /* Not tcflush() */
       bool saw_eol = totalread > 0 && strchr ("\r\n", ptr0[totalread -1]);
-      mask_switch_to_pcon_in (false, saw_eol);
+      mask_switch_to_pcon_in (false, saw_eol || len == 0);
     }
 }
 
@@ -2224,6 +2227,15 @@ fhandler_pty_master::write (const void *ptr, size_t len)
       ReleaseMutex (input_mutex);
 
       return len;
+    }
+
+  if (to_be_read_from_pcon () && !get_ttyp ()->pcon_activated
+      && get_ttyp ()->pcon_input_state == tty::to_cyg)
+    {
+      WaitForSingleObject (input_mutex, INFINITE);
+      fhandler_pty_slave::transfer_input (tty::to_nat, from_master,
+					  get_ttyp (), input_available_event);
+      ReleaseMutex (input_mutex);
     }
 
   line_edit_status status = line_edit (p, len, ti, &ret);


### PR DESCRIPTION
As reported in https://github.com/git-for-windows/git/issues/3579, when using MSYS2 runtime v3.3.3 in a regular Git Bash, after `git config -e --global` launched `vim` and the editor was closed, seemingly random characters are "ghost-typed". Concretely, I saw `1R77;30502;0c10;rgb:bfbf/bfbf/bfbf11;rgb:0000/0000/0000` being "ghost-typed" every time Git had called vi for editing a file.

To be precise, the hexdump -C output is this:

```
00000000  1b 5b 32 3b 32 52 1b 5b  33 3b 31 52 1b 5b 3e 37  |.[2;2R.[3;1R.[>7|
00000010  37 3b 33 30 35 30 32 3b  30 63 1b 5d 31 30 3b 72  |7;30502;0c.]10;r|
00000020  67 62 3a 62 66 62 66 2f  62 66 62 66 2f 62 66 62  |gb:bfbf/bfbf/bfb|
00000030  66 07 1b 5d 31 31 3b 72  67 62 3a 30 30 30 30 2f  |f..]11;rgb:0000/|
00000040  30 30 30 30 2f 30 30 30  30 07                    |0000/0000.|
```

This is the response for a `CSI [ 6n` request, and the response was clearly routed to the terminal by mistake instead of the process that requested it.

The regression was actually introduced into v3.2.0, but not noticed earlier. [I reported the issue](https://sourceware.org/pipermail/cygwin-patches/2021q4/011587.html) after trying to figure out a workaround for three days, without success, and the original author of the commit introducing the regression provided a patch that works around it. I do not yet understand the patch, but let's take the patch for now because the regression is pretty severe.

While at it, also include a fixup that handles two previously unhandled instances of the `cygwin-pty` pipe (which is renamed to `msys-pty` in MSYS2) that I spotted while working on this bug.