### PR TITLE
posix_spawn: fix get/set uid/gid calls for 32 bit Cygwin

### DIFF
--- a/newlib/libc/posix/posix_spawn.c
+++ b/newlib/libc/posix/posix_spawn.c
@@ -146,6 +146,17 @@ typedef struct __posix_spawn_file_actions_entry {
  * Spawn routines
  */
 
+#if defined (__CYGWIN__) && defined (__i386__)
+extern int getgid32 (void);
+extern int getuid32 (void);
+extern int setegid32 (gid_t egid);
+extern int seteuid32 (uid_t euid);
+#define setegid setegid32
+#define seteuid seteuid32
+#define getgid getgid32
+#define getuid getuid32
+#endif
+
 static int
 process_spawnattr(const posix_spawnattr_t sa)
 {


### PR DESCRIPTION
Addresses msys2/MSYS2-packages#2801.  It turns out that vfork is actually faster than posix_spawn in make, so the original issue is less urgent to fix, but perhaps other things may try to use posix_spawn with the `POSIX_SPAWN_RESETIDS` flag and fail.
