### PR TITLE
path_conv: a directory with `.lnk` suffix is not a `.lnk` file

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -3498,6 +3498,7 @@ restart:
 	 hasn't been found. */
       if (ext_tacked_on && !had_ext && (fileattr & FILE_ATTRIBUTE_DIRECTORY))
 	{
+	  fileattr = INVALID_FILE_ATTRIBUTES;
 	  set_error (ENOENT);
 	  continue;
 	}


### PR DESCRIPTION
This clears a variable when we half-detected a symlink emulated via a `.lnk` file (and when it turned out that it was a directory instead).

This fixes https://github.com/msys2/msys2-runtime/issues/81