### PR TITLE
Convert the trailing colon to semi-colon while converting paths

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -602,8 +602,6 @@ void ppl_convert(const char** from, const char* to, char** dst, const char* dste
 
     if (!prev_was_simc) {
         subp_convert(&beg, it, is_url, dst, dstend);
-    } else {
-        *dst -= 1;
     }
 }
 


### PR DESCRIPTION
Previously, trailing colons were stripped which caused some issues,
with texinfo package, where trailing `:` or `;` would mean adding standard
library paths, and stripping it causes errors. Logically, converting those
trailing colons to semi-colons seems right rather than stripping them.

Fixes https://github.com/msys2/msys2-runtime/issues/94
Also see, https://github.com/msys2/path_convert/pull/5