### PR TITLE
uname: allow setting the system name to CYGWIN

### DIFF
--- a/winsup/cygwin/uname.cc
+++ b/winsup/cygwin/uname.cc
@@ -23,6 +23,24 @@ extern "C" int getdomainname (char *__name, size_t __len);
 #define ATTRIBUTE_NONSTRING
 #endif
 
+static const char*
+get_sysname()
+{
+#ifdef __MSYS__
+  char* msystem = getenv("MSYSTEM");
+  if (!msystem || strcmp(msystem, "MSYS") == 0)
+    return "MSYS";
+  else if (strcmp(msystem, "CYGWIN") == 0)
+    return "CYGWIN";
+  else if (strstr(msystem, "32") != NULL)
+    return "MINGW32";
+  else
+    return "MINGW64";
+#else
+  return "CYGWIN";
+#endif
+}
+
 /* uname: POSIX 4.4.1.1 */
 
 /* New entrypoint for applications since API 335 */
@@ -36,12 +54,9 @@ uname_x (struct utsname *name)
 
       memset (name, 0, sizeof (*name));
       /* sysname */
-      char* msystem = getenv("MSYSTEM");
-      const char* msystem_sysname = "MSYS";
-      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
-        msystem_sysname = (strstr(msystem, "32") != NULL) ? "MINGW32" : "MINGW64";;
+      const char* sysname = get_sysname();
       __small_sprintf (name->sysname, "%s_%s-%u%s",
-		       msystem_sysname,
+		       sysname,
 		       wincap.osname (), wincap.build_number (),
 		       wincap.is_wow64 () ? "-WOW64" : "");
       /* nodename */
@@ -103,15 +118,8 @@ uname (struct utsname *in_name)
       char *snp = strstr  (cygwin_version.dll_build_date, "SNP");
 
       memset (name, 0, sizeof (*name));
-#ifdef __MSYS__
-      char* msystem = getenv("MSYSTEM");
-      const char* msystem_sysname = "MSYS";
-      if (msystem != NULL && *msystem && strcmp(msystem, "MSYS") != 0)
-        msystem_sysname = (strstr(msystem, "32") != NULL) ? "MINGW32" : "MINGW64";
-      __small_sprintf (name->sysname, "%s_%s", msystem_sysname, wincap.osname ());
-#else
-      __small_sprintf (name->sysname, "CYGWIN_%s", wincap.osname ());
-#endif
+      const char* sysname = get_sysname();
+      __small_sprintf (name->sysname, "%s_%s", sysname, wincap.osname ());
 
       /* Add a hint to the sysname, that we're running under WOW64.  This might
 	 give an early clue if somebody encounters problems. */


### PR DESCRIPTION
We are currently trying to move our cygwin build environment closer
to cygwin and some autotools/bash based build systems call "uname -s"
to figure out the OS and in many cases only handle the cygwin case, so
we have to patch them.

With this instead of patching we can set MSYSTEM=CYGWIN and change
uname output that way.

The next step would be to always output CYGWIN in an msys env by default,
but for now this allows us to get rid of all the patches without
affecting users.