### PR TITLE
Allow empty-valued environment variables to be passed to non-MSYS programs

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -36,6 +36,7 @@ static char **lastenviron;
 /* Parse CYGWIN options */
 
 static NO_COPY bool export_settings = false;
+static bool emptyenvvalues = true;
 
 enum settings
   {
@@ -130,6 +131,7 @@ static struct parse_thing
   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
   {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
   {"nativeinnerlinks", {&nativeinnerlinks}, setbool, NULL, {{false}, {true}}},
+  {"emptyenvvalues", {&emptyenvvalues}, setbool, NULL, {{false}, {true}}},
   {NULL, {0}, setdword, 0, {{0}, {0}}}
 };
 
@@ -1339,7 +1341,7 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
 	     Note that this doesn't stop invalid strings without '=' in it
 	     etc., but we're opting for speed here for now.  Adding complete
 	     checking would be pretty expensive. */
-	  if (len == 1)
+	  if (len == 1 || (!emptyenvvalues && !*rest))
 	    continue;
 
 	  /* See if this entry requires posix->win32 conversion. */

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -1217,7 +1217,11 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
     {
       bool calc_tl = !no_envblock;
 #ifdef __MSYS__
-      if (!keep_posix)
+      if (ascii_strncasematch(*srcp, "MSYS=", 5))
+        {
+          parse_options (*srcp + 5);
+	}
+      else if (!keep_posix)
         {
           /* Don't pass timezone environment to non-msys applications */
           if (ascii_strncasematch(*srcp, "TZ=", 3))

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -1339,11 +1339,11 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
 	     Note that this doesn't stop invalid strings without '=' in it
 	     etc., but we're opting for speed here for now.  Adding complete
 	     checking would be pretty expensive. */
-	  if (len == 1 || !*rest)
+	  if (len == 1)
 	    continue;
 
 	  /* See if this entry requires posix->win32 conversion. */
-	  conv = getwinenv (*srcp, rest, &temp);
+	  conv = !*rest ? NULL : getwinenv (*srcp, rest, &temp);
 	  if (conv)
 	    {
 	      p = conv->native;	/* Use win32 path */
@@ -1357,7 +1357,7 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
 		}
 	    }
 #ifdef __MSYS__
-	  else if (!keep_posix) {
+	  else if (!keep_posix && *rest) {
 	    char *win_arg = arg_heuristic_with_exclusions
 		   (*srcp, msys2_env_conv_excl_env, msys2_env_conv_excl_count);
 	    debug_printf("WIN32_PATH is %s", win_arg);


### PR DESCRIPTION
This addresses https://github.com/msys2/msys2-runtime/issues/99 and also reduces the difference between the MSYS2 runtime and Git for Windows' fork of the same.