### PR TITLE
fixup! Revert "Default to `disable_pcon`"

### DIFF
--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -74,7 +74,7 @@ bool pipe_byte;
 bool reset_com;
 bool wincmdln = true;
 winsym_t allow_winsymlinks = WSYM_deepcopy;
-bool disable_pcon = true;
+bool disable_pcon;
 bool winjitdebug = false;
 bool nativeinnerlinks = true;
 


### PR DESCRIPTION
This reverts commit 8e89fffcfb0884da1398dd55f0d0cc57294549ec.

We want to try enabling it by default again, see #98