### PR TITLE
path_conv: be a lot more careful when to keep a trailing slash

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1254,17 +1254,17 @@ path_conv::check (const char *src, unsigned opt,
 		cfree (wide_path);
 	      wide_path = NULL;
 	    }
-	}
 
-      if (need_directory)
-	{
-	  size_t n = strlen (this->path);
-	  /* Do not add trailing \ to UNC device names like \\.\a: */
-	  if (this->path[n - 1] != '\\' &&
-	      (strncmp (this->path, "\\\\.\\", 4) != 0))
+	  if (need_directory)
 	    {
-	      this->modifiable_path ()[n] = '\\';
-	      this->modifiable_path ()[n + 1] = '\0';
+	      size_t n = strlen (this->path);
+	      /* Do not add trailing \ to UNC device names like \\.\a: */
+	      if (this->path[n - 1] != '\\' &&
+		  (strncmp (this->path, "\\\\.\\", 4) != 0))
+		{
+		  this->modifiable_path ()[n] = '\\';
+		  this->modifiable_path ()[n + 1] = '\0';
+		}
 	    }
 	}
 


### PR DESCRIPTION
On FAT file systems, the normalized path is used to fake inode numbers. As a result, `Y:\directory\` and `Y:\directory` have different inode numbers!!!

One consequence of this bug has been reported on the Git for Windows: the `find` and `rm` commands can error out on FAT file systems with very confusing "No such file or directory" errors, for no good reason (see https://github.com/git-for-windows/git/issues/1497 and https://github.com/git-for-windows/git/issues/1536).

This bug had been fixed in Cygwin as early as 1997... and we reintroduced it in MSYS2.

Let's fix it again.

This patch has been carried in Git for Windows for several years, with no further bug reports.

While at it, replace the very sad, sad, grammatically-incorrect one-liner of a commit message with a detailed explanation of the context, the intent and the justification of the code change.