### PR TITLE
Fix `Bad address` when running `cmd /c [...]`

### DIFF
--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -198,6 +198,8 @@ handle (int fd, bool writing)
 static bool
 is_console_app (WCHAR *filename)
 {
+  if (filename == NULL)
+    return true; /* The command executed is command.com or cmd.exe. */
   HANDLE h;
   const int id_offset = 92;
   h = CreateFileW (filename, GENERIC_READ, FILE_SHARE_READ,


### PR DESCRIPTION
In 2b4f986e49 (Cygwin: pty: Treat *.bat and *.cmd as a non-cygwin console app., 2022-07-31), we introduced a bug fix that  specifically looks for a suffix of the command's file name.

However, that file name might be set to `NULL`, namely when `null_app_name == true`, which is the case when we detected a command-line `cmd /c [...]`.

But the commit mentioned above did not account for that possibility, instead assuming that it always has to check the file name for a `.bat` or `.cmd` suffix. As a consequence, `cmd /c [...]` invocations are completely broken in v3.3.6, resulting in a `Bad address` error.

Let's guard the code properly so that it does not try to look at the file name suffix of `(WCHAR *)NULL`.

This fixes https://github.com/msys2/msys2-runtime/issues/108