### PR TITLE
Implement a `winsymlinks` mode that prefers native symlinks, falling back to the deep copy mode

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -92,6 +92,8 @@ set_winsymlinks (const char *buf)
 			? WSYM_nativestrict : WSYM_native;
   else if (ascii_strncasematch (buf, "deepcopy", 8))
     allow_winsymlinks = WSYM_deepcopy;
+  else if (ascii_strncasematch (buf, "nativeordeepcopy", 8))
+    allow_winsymlinks = WSYM_native_or_deepcopy;
   else
     allow_winsymlinks = WSYM_sysfile;
 }

--- a/winsup/cygwin/globals.cc
+++ b/winsup/cygwin/globals.cc
@@ -57,7 +57,8 @@ enum winsym_t
   WSYM_nativestrict,
   WSYM_nfs,
   WSYM_sysfile,
-  WSYM_deepcopy
+  WSYM_deepcopy,
+  WSYM_native_or_deepcopy
 };
 
 exit_states NO_COPY exit_state;

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2336,6 +2336,9 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
       else if ((wsym_type == WSYM_native || wsym_type == WSYM_nativestrict)
 	       && !(win32_newpath.fs_flags () & FILE_SUPPORTS_REPARSE_POINTS))
 	wsym_type = WSYM_default;
+      else if (wsym_type == WSYM_native_or_deepcopy
+	       && !(win32_newpath.fs_flags () & FILE_SUPPORTS_REPARSE_POINTS))
+	wsym_type = WSYM_deepcopy;
 
       /* Attach .lnk suffix when shortcut is requested. */
       if (wsym_type == WSYM_lnk && !win32_newpath.exists ()
@@ -2368,6 +2371,7 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	  res = symlink_nfs (oldpath, win32_newpath);
 	  __leave;
 	case WSYM_deepcopy:
+case_WSYM_deepcopy:
 	  res = symlink_deepcopy (oldpath, win32_newpath);
 	  if (!res || res == -1)
 	    __leave;
@@ -2376,6 +2380,7 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	  break;
 	case WSYM_native:
 	case WSYM_nativestrict:
+	case WSYM_native_or_deepcopy:
 	  res = symlink_native (oldpath, win32_newpath);
 	  if (!res)
 	    __leave;
@@ -2385,6 +2390,12 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	    {
 	      __seterrno ();
 	      __leave;
+	    }
+	  /* With deepcopy fall back? Let's do that, then */
+	  if (res == -1 && wsym_type == WSYM_native_or_deepcopy)
+	    {
+	      wsym_type = WSYM_deepcopy;
+	      goto case_WSYM_deepcopy;
 	    }
 	  /* Otherwise, fall back to default symlink type. */
 	  wsym_type = WSYM_default;

--- a/winsup/doc/cygwinenv.xml
+++ b/winsup/doc/cygwinenv.xml
@@ -104,7 +104,7 @@ back to the parent process.</para>
 </listitem>
 
 <listitem>
-<para><envar>winsymlinks:{lnk,native,nativestrict,sys,deepcopy}</envar></para>
+<para><envar>winsymlinks:{lnk,native,nativestrict,sys,deepcopy,nativeordeepcopy}</envar></para>
 
 <itemizedlist mark="square">
 <listitem>
@@ -140,6 +140,14 @@ will be created at the target (a "deep" copy in the case of directories, i.e.
 the source directory will be copied recursively). This mode makes a trade-off
 between compatibility and interoperability with Win32 programs, favoring the
 latter.</para>
+</listitem>
+
+<listitem>
+<para>If set to <literal>winsymlinks:nativeordeepcopy</literal> Cygwin creates
+symlinks as native Windows symlinks if supported (i.e. on file systems
+supporting symbolic links, and when the current user is permitted to create
+symbolic links, e.g. in Windows 10's "Developer Mode"), and fall back to
+creating a deep copy in case symlinks are not supported.</para>
 </listitem>
 </itemizedlist>
 

--- a/winsup/doc/cygwinenv.xml
+++ b/winsup/doc/cygwinenv.xml
@@ -104,7 +104,7 @@ back to the parent process.</para>
 </listitem>
 
 <listitem>
-<para><envar>winsymlinks:{lnk,native,nativestrict,sys}</envar></para>
+<para><envar>winsymlinks:{lnk,native,nativestrict,sys,deepcopy}</envar></para>
 
 <itemizedlist mark="square">
 <listitem>
@@ -132,6 +132,14 @@ system call will immediately fail.</para>
 <para>If set to <literal>winsymlinks:sys</literal>, Cygwin creates symlinks as
 plain files with the <literal>system</literal> attribute, containing a magic
 cookie followed by the path to which the link points.</para>
+</listitem>
+
+<listitem>
+<para>If set to <literal>winsymlinks:deepcopy</literal>, a copy of the source
+will be created at the target (a "deep" copy in the case of directories, i.e.
+the source directory will be copied recursively). This mode makes a trade-off
+between compatibility and interoperability with Win32 programs, favoring the
+latter.</para>
 </listitem>
 </itemizedlist>
 


### PR DESCRIPTION
It surprises new MSYS2 users no end that `ln -s` does not create symbolic links at all, but deep copies (and with an exit code indicating success!). This did not at all match the expectations of those users who were familiar with Unix' concept of symbolic links and thought that they could rely on MSYS2 providing those, too, or fail with a non-zero exit code.

[Historical reasons](https://everything2.com/user/Jargon/writeups/hysterical+reasons) are at play here: When MSYS2 was started (or was that already the behavior of MSys? I forget...), symbolic links were not supported on Windows, at least not really: you had to have administrator privileges to create them (but not to delete them... 🤷) in Windows Vista, and before that, Windows simply had no idea about symbolic links.

So what about Cygwin? Well, Cygwin had something like support for symbolic links, using `.lnk` files for the emulation. The only problem? You had to stay within Cygwin's walled garden to make use of them. All non-Cygwin applications would react with a less or more unpleasant "huh?!?" when encountering those "symbolic links".

That's why MSYS2 chose to deep-copy by default. At least that way `./configure` would still work for those projects that required symbolic links. This was instrumental in getting MSYS2's package ecosystem off the ground.

Even when a Windows 10 update introduced support for creating symbolic links without elevation as long as Windows was run in Developer Mode, the created symbolic links are not _completely_ what Unix/Linux/macOS users may be used to, as Windows discerns between directory symlinks and file symlinks.

Be that as it may, now that we've dropped Windows 7 and Windows 8 support, it may be a good time to start switching the default to creating actual symbolic links by default.

Since we still support Windows 8.1 (and a couple of Windows 10 versions that do not allow creating symbolic links in non-elevated operations, even in Developer Mode), we cannot simply switch to a mode where the MSYS2 runtime creates symbolic links when asked for, but we have to have a mode where the MSYS2 runtime first checks whether that is possible with the Windows version on which it is running, and if not, falls back to the deep-copy.

This PR does precisely that: implement that mode, but does _not_ yet flip the default away from `deepcopy`. The reason is that I want this to be tested by volunteers (myself included) first, and once it is deemed robust and stable enough, flip the default to `nativeordeepcopy`.

This addresses https://github.com/msys2/msys2-runtime/issues/113.