### PR TITLE
ci: avoid using Node.js 12 Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup-msys2
         uses: msys2/setup-msys2@v2
@@ -30,7 +30,7 @@ jobs:
           make DESTDIR="$(pwd)"/_dest install
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: install
           path: _dest/


### PR DESCRIPTION
I noticed [in this build](https://github.com/msys2/msys2-runtime/actions/runs/3420824668#annotations) that we're using outdated Actions. Let's upgrade them and avoid having our CI fail due to use of deprecated Node.js versions