### PR TITLE
Revert "Cygwin: x86_64: add wmemset assembler entry point"

### DIFF
--- a/winsup/cygwin/x86_64/memset.s
+++ b/winsup/cygwin/x86_64/memset.s
@@ -67,11 +67,3 @@ L1:     rep
 	movq	16(%rsp),%rdi
 	ret
 	.seh_endproc
-
-	.globl  wmemset
-	.seh_proc wmemset
-wmemset:
-	.seh_endprologue
-	shlq	$1,%r8		/* cnt * sizeof (wchar_t) */
-	jmp	memset
-	.seh_endproc


### PR DESCRIPTION
This partly reverts commit 188d5f6c9ad5cbbd6f0fcb9aaf15bc9870597910.

See https://cygwin.com/pipermail/cygwin/2022-December/252699.html