### PR TITLE
Revert "Cygwin: Enable dynamicbase on the Cygwin DLL by default"

### DIFF
--- a/winsup/cygwin/Makefile.am
+++ b/winsup/cygwin/Makefile.am
@@ -585,8 +585,7 @@ $(NEW_DLL_NAME): $(LDSCRIPT) libdll.a $(VERSION_OFILES) $(LIBSERVER)\
 		  $(newlib_build)/libm.a $(newlib_build)/libc.a
 	$(AM_V_CXXLD)$(CXX) $(CXXFLAGS) \
 	-mno-use-libstdc-wrappers \
-	-Wl,--gc-sections -nostdlib -Wl,-T$(LDSCRIPT) \
-	-Wl,--dynamicbase -static \
+	-Wl,--gc-sections -nostdlib -Wl,-T$(LDSCRIPT) -static \
 	-Wl,--heap=0 -Wl,--out-implib,msysdll.a -shared -o $@ \
 	-e @DLL_ENTRY@ $(DEF_FILE) \
 	-Wl,-whole-archive libdll.a -Wl,-no-whole-archive \


### PR DESCRIPTION
This reverts commit 943433b00cacdde0cb9507d0178770a2fb67bd71.

This seems to fix fork errors under Docker, see
https://cygwin.com/pipermail/cygwin/2022-December/252711.html