### PR TITLE
[backport] Cygwin: path_conv: make sure sym.path_flags is always initialized

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -725,6 +725,7 @@ path_conv::check (const char *src, unsigned opt,
 	  /* FIXME: Do we have to worry about multiple \'s here? */
 	  component = 0;		// Number of translated components
 	  sym.contents[0] = '\0';
+	  sym.path_flags = 0;
 
 	  int symlen = 0;
 
@@ -919,7 +920,6 @@ path_conv::check (const char *src, unsigned opt,
 		{
 		  fileattr = 0;
 		  mount_flags = sym.mount_flags;
-		  path_flags = sym.path_flags;
 		  if (component)
 		    {
 		      error = ENOTDIR;

--- a/winsup/cygwin/release/3.4.4
+++ b/winsup/cygwin/release/3.4.4
@@ -1,0 +1,5 @@
+Bug Fixes
+---------
+
+- Fix an uninitialized variable having weird side-effects in path handling.
+  Addresses: https://cygwin.com/pipermail/cygwin/2022-December/252734.html


### PR DESCRIPTION
Commit c1023ee353705 introduced a split between mount flags and path flags.  It didn't initialize symlink_info::path_flags in path_conv::check, because that's done in symlink_info::check.

However, there are two code paths expecting symlink_info::path_flags being already initialized and both skip symlink_info::check.

Make sure symlink_info::path_flags is initalized to 0 early in path_conv::check.

Fixes: c1023ee353705 ("Cygwin: path_conv: decouple path_types from mount types")
Signed-off-by: Corinna Vinschen <corinna@vinschen.de>