### PR TITLE
dumper: avoid linker problem when `libbfd` depends on `libsframe`

### DIFF
--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -120,6 +120,11 @@ AC_CHECK_LIB([bfd], [bfd_init], [true],
 
 AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
 
+AC_CHECK_LIB([sframe], [sframe_decode],
+	     AC_MSG_NOTICE([Detected libsframe; Assuming that libbfd depends on it]), [true])
+
+AM_CONDITIONAL(HAVE_LIBSFRAME, [test "x$ac_cv_lib_sframe_sframe_decode" = "xyes"])
+
 AC_CONFIG_FILES([
     Makefile
     cygwin/Makefile

--- a/winsup/utils/Makefile.am
+++ b/winsup/utils/Makefile.am
@@ -87,6 +87,10 @@ profiler_CXXFLAGS = -I$(srcdir) -idirafter ${top_srcdir}/cygwin/local_includes -
 profiler_LDADD = $(LDADD) -lntdll
 cygps_LDADD = $(LDADD) -lpsapi -lntdll
 
+if HAVE_LIBSFRAME
+dumper_LDADD += -lsframe
+endif
+
 if CROSS_BOOTSTRAP
 SUBDIRS = mingw
 endif


### PR DESCRIPTION
A recent binutils version introduced `libsframe` and made it a dependency of `libbfd`. Which means that we have to link that library into `dumper.exe`, too, if it exists.

The symptom of failing to link to said new library looks like [this](https://github.com/git-for-windows/msys2-runtime/actions/runs/4048916874/jobs/6964719627#step:4:2489):

```
[...]
  CXXLD    dumper.exe
/usr/lib/gcc/x86_64-pc-msys/11.3.0/../../../../x86_64-pc-msys/bin/ld: /usr/lib/gcc/x86_64-pc-msys/11.3.0/../../../../lib/libbfd.a(elf-sframe.o):(.text+0x11c): undefined reference to `sframe_decode'
make[5]: Leaving directory '/d/a/msys2-runtime/msys2-runtime/x86_64-pc-msys/winsup/utils'
/usr/lib/gcc/x86_64-pc-msys/11.3.0/../../../../x86_64-pc-msys/bin/ld: /usr/lib/gcc/x86_64-pc-msys/11.3.0/../../../../lib/libbfd.a(elf-sframe.o):(.text+0x131): undefined reference to `sframe_decoder_get_num_fidx'
[...]
```