### PR TITLE
In container posix semantics

### DIFF
--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -731,7 +731,10 @@ _unlink_nt (path_conv &pc, bool shareable)
       /* Trying to delete in-use executables and DLLs using
          FILE_DISPOSITION_POSIX_SEMANTICS returns STATUS_CANNOT_DELETE.
 	 Fall back to the default method. */
-      if (status != STATUS_CANNOT_DELETE)
+      /* Additionaly that returns STATUS_INVALID_PARAMETER
+         on a bind mounted fs in hyper-v container. Falling back too. */
+      if (status != STATUS_CANNOT_DELETE
+          && status != STATUS_INVALID_PARAMETER)
 	goto out;
     }
 

--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -2438,6 +2438,7 @@ rename2 (const char *oldpath, const char *newpath, unsigned int at2flags)
 			    && !oldpc.isremote ()
 			    && oldpc.fs_is_ntfs ();
 
+ignore_posix_semantics_retry:
       /* Opening the file must be part of the transaction.  It's not sufficient
 	 to call only NtSetInformationFile under the transaction.  Therefore we
 	 have to start the transaction here, if necessary.  Don't start
@@ -2682,6 +2683,15 @@ skip_pre_W10_checks:
 	    unlink_nt (*removepc);
 	  res = 0;
 	}
+      else if (use_posix_semantics && status == STATUS_INVALID_PARAMETER)
+        {
+          /* NtSetInformationFile returns STATUS_INVALID_PARAMETER
+             on a bind mounted file system in hyper-v container
+             with FILE_RENAME_POSIX_SEMANTICS.
+             Disable the use_posix semntics flag and retry. */
+          use_posix_semantics = 0;
+          goto ignore_posix_semantics_retry;
+        }
       else
 	__seterrno_from_nt_status (status);
     }

--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -736,6 +736,9 @@ _unlink_nt (path_conv &pc, bool shareable)
       if (status != STATUS_CANNOT_DELETE
           && status != STATUS_INVALID_PARAMETER)
 	goto out;
+      debug_printf ("NtSetInformationFile (%S, FileDispositionInformationEx)"
+                    " returns %y with posix semantics. Disable it and retry.",
+                    pc.get_nt_native_path (), status);
     }
 
   /* If the R/O attribute is set, we have to open the file with
@@ -2689,6 +2692,11 @@ skip_pre_W10_checks:
              on a bind mounted file system in hyper-v container
              with FILE_RENAME_POSIX_SEMANTICS.
              Disable the use_posix semntics flag and retry. */
+          debug_printf ("NtSetInformationFile "
+                        "(%S, %S, FileRenameInformationEx) failed "
+                        "with posix semantics. Disable it and retry.",
+                        oldpc.get_nt_native_path (),
+                        newpc.get_nt_native_path ());
           use_posix_semantics = 0;
           goto ignore_posix_semantics_retry;
         }


### PR DESCRIPTION
#59 complains that remove does not work in docker volume folder.
That seems to mounted folder does not support *_POSIX_SEMANTICS functions in hyper-v container.
https://ci.appveyor.com/project/YO4/test-msys2-in-container/builds/46432262

Since it is unclear how to determine in advance whether posix semantics will work, fall back to the conventional method when an error occurs.

Functions affected are unlink(), rename(), and their derivatives.