### PR TITLE
CI: build with --disable-dependency-tracking

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
         shell: msys2 {0}
         run: |
           (cd winsup && ./autogen.sh)
-          ./configure
+          ./configure --disable-dependency-tracking
           make -j8
 
       - name: Install


### PR DESCRIPTION
We only build once in CI, so dependency tracking isn't needed. This saves 3-4 minutes in CI.

----

Not sure if that's worth it, but seemed nice.