### PR TITLE
Stop assuming that there are no spaces in POSIX-style paths

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -201,7 +201,7 @@ void ppl_convert(const char** from, const char* to, char** dst, const char* dste
 
 
 void find_end_of_posix_list(const char** to, int* in_string) {
-    for (; **to != '\0' && (in_string ? (**to != *in_string) : **to != ' '); ++*to) {
+    for (; **to != '\0' && (!in_string || **to != *in_string); ++*to) {
     }
 
     if (**to == *in_string) {
@@ -300,12 +300,6 @@ const char* convert(char *dst, size_t dstlen, const char *src) {
                 in_string = *srcit;
             }
             continue;
-        }
-
-        if (isspace(*srcit)) {
-            //sub_convert(&srcbeg, &srcit, &dstit, dstend, &in_string);
-            //srcbeg = srcit + 1;
-            break;
         }
     }
 


### PR DESCRIPTION
Git's test suite most prominently sports a POSIX path with a space in it: the tests are executed in directories whose names have the form 'trash directory.t0123-blub'. Therefore, we *must* handle those names correctly.

This fix makes Git's t1504-ceiling-dirs.sh pass.