### PR TITLE
[backport] Cygwin: Fix compiling with w32api-headers v11.0.0

### DIFF
--- a/winsup/cygwin/local_includes/ntdll.h
+++ b/winsup/cygwin/local_includes/ntdll.h
@@ -518,10 +518,12 @@ enum
   FILE_RENAME_IGNORE_READONLY_ATTRIBUTE			= 0x40
 };
 
+#if (__MINGW64_VERSION_MAJOR < 11)
 enum
 {
   FILE_CS_FLAG_CASE_SENSITIVE_DIR			= 0x01
 };
+#endif
 
 enum
 {


### PR DESCRIPTION
This backports  https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=1c63eaace825e32f2d03a3a228a40b1019b94c71 to fix the build with mingw-w64 v11