### PR TITLE
Backports for fixing c89 compat for cpuset.h

### DIFF
--- a/winsup/cygwin/include/sys/cpuset.h
+++ b/winsup/cygwin/include/sys/cpuset.h
@@ -9,7 +9,8 @@ details. */
 #ifndef _SYS_CPUSET_H_
 #define _SYS_CPUSET_H_
 
-#include <sys/cdefs.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,14 +45,14 @@ __cpuset_alloc_size (int num)
 static __inline cpu_set_t *
 __cpuset_alloc (int num)
 {
-  return (cpu_set_t *) __builtin_malloc (CPU_ALLOC_SIZE(num));
+  return (cpu_set_t *) malloc (CPU_ALLOC_SIZE(num));
 }
 
 #define CPU_FREE(set) __cpuset_free (set)
 static __inline void
 __cpuset_free (cpu_set_t *set)
 {
-  __builtin_free (set);
+  free (set);
 }
 
 /* These _S macros operate on dynamically-sized cpu sets of size 'siz' bytes */
@@ -59,7 +60,7 @@ __cpuset_free (cpu_set_t *set)
 static __inline void
 __cpuset_zero_s (size_t siz, cpu_set_t *set)
 {
-  (void) __builtin_memset (set, 0, siz);
+  (void) memset (set, 0, siz);
 }
 
 #define CPU_SET_S(cpu, siz, set) __cpuset_set_s (cpu, siz, set)

--- a/winsup/cygwin/include/sys/cpuset.h
+++ b/winsup/cygwin/include/sys/cpuset.h
@@ -9,14 +9,16 @@ details. */
 #ifndef _SYS_CPUSET_H_
 #define _SYS_CPUSET_H_
 
+#include <sys/cdefs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef __SIZE_TYPE__ __cpu_mask;
-#define __CPU_SETSIZE 1024  // maximum number of logical processors tracked
-#define __NCPUBITS (8 * sizeof (__cpu_mask))  // max size of processor group
-#define __CPU_GROUPMAX (__CPU_SETSIZE / __NCPUBITS)  // maximum group number
+#define __CPU_SETSIZE 1024  /* maximum number of logical processors tracked */
+#define __NCPUBITS (8 * sizeof (__cpu_mask))  /* max size of processor group */
+#define __CPU_GROUPMAX (__CPU_SETSIZE / __NCPUBITS)  /* maximum group number */
 
 #define __CPUELT(cpu)  ((cpu) / __NCPUBITS)
 #define __CPUMASK(cpu) ((__cpu_mask) 1 << ((cpu) % __NCPUBITS))
@@ -32,21 +34,21 @@ int __sched_getaffinity_sys (pid_t, size_t, cpu_set_t *);
 /* These macros alloc or free dynamically-sized cpu sets of size 'num' cpus.
    Allocations are padded such that full-word operations can be done easily. */
 #define CPU_ALLOC_SIZE(num) __cpuset_alloc_size (num)
-static inline size_t
+static __inline size_t
 __cpuset_alloc_size (int num)
 {
   return (size_t) (((num + __NCPUBITS - 1) / __NCPUBITS) * sizeof (__cpu_mask));
 }
 
 #define CPU_ALLOC(num) __cpuset_alloc (num)
-static inline cpu_set_t *
+static __inline cpu_set_t *
 __cpuset_alloc (int num)
 {
   return (cpu_set_t *) __builtin_malloc (CPU_ALLOC_SIZE(num));
 }
 
 #define CPU_FREE(set) __cpuset_free (set)
-static inline void
+static __inline void
 __cpuset_free (cpu_set_t *set)
 {
   __builtin_free (set);
@@ -54,14 +56,14 @@ __cpuset_free (cpu_set_t *set)
 
 /* These _S macros operate on dynamically-sized cpu sets of size 'siz' bytes */
 #define CPU_ZERO_S(siz, set) __cpuset_zero_s (siz, set)
-static inline void
+static __inline void
 __cpuset_zero_s (size_t siz, cpu_set_t *set)
 {
   (void) __builtin_memset (set, 0, siz);
 }
 
 #define CPU_SET_S(cpu, siz, set) __cpuset_set_s (cpu, siz, set)
-static inline void
+static __inline void
 __cpuset_set_s (int cpu, size_t siz, cpu_set_t *set)
 {
   if (cpu >= 0 && cpu < 8 * siz)
@@ -69,7 +71,7 @@ __cpuset_set_s (int cpu, size_t siz, cpu_set_t *set)
 }
 
 #define CPU_CLR_S(cpu, siz, set) __cpuset_clr_s (cpu, siz, set)
-static inline void
+static __inline void
 __cpuset_clr_s (int cpu, size_t siz, cpu_set_t *set)
 {
   if (cpu >= 0 && cpu < 8 * siz)
@@ -77,7 +79,7 @@ __cpuset_clr_s (int cpu, size_t siz, cpu_set_t *set)
 }
 
 #define CPU_ISSET_S(cpu, siz, set) __cpuset_isset_s (cpu, siz, set)
-static inline int
+static __inline int
 __cpuset_isset_s (int cpu, size_t siz, cpu_set_t *set)
 {
   int res = 0;
@@ -87,45 +89,48 @@ __cpuset_isset_s (int cpu, size_t siz, cpu_set_t *set)
 }
 
 #define CPU_COUNT_S(siz, set) __cpuset_count_s (siz, set)
-static inline int
+static __inline int
 __cpuset_count_s (size_t siz, cpu_set_t *set)
 {
-  int res = 0;
-  for (int i = 0; i < siz / sizeof (__cpu_mask); i++)
+  int i, res = 0;
+  for (i = 0; i < siz / sizeof (__cpu_mask); i++)
     res += __builtin_popcountl ((set)->__bits[i]);
   return res;
 }
 
 #define CPU_AND_S(siz, dst, src1, src2) __cpuset_and_s (siz, dst, src1, src2)
-static inline void
+static __inline void
 __cpuset_and_s (size_t siz, cpu_set_t *dst, cpu_set_t *src1, cpu_set_t *src2)
 {
-  for (int i = 0; i < siz / sizeof (__cpu_mask); i++)
+  int i;
+  for (i = 0; i < siz / sizeof (__cpu_mask); i++)
     (dst)->__bits[i] = (src1)->__bits[i] & (src2)->__bits[i];
 }
 
 #define CPU_OR_S(siz, dst, src1, src2) __cpuset_or_s (siz, dst, src1, src2)
-static inline void
+static __inline void
 __cpuset_or_s (size_t siz, cpu_set_t *dst, cpu_set_t *src1, cpu_set_t *src2)
 {
-  for (int i = 0; i < siz / sizeof (__cpu_mask); i++)
+  int i;
+  for (i = 0; i < siz / sizeof (__cpu_mask); i++)
     (dst)->__bits[i] = (src1)->__bits[i] | (src2)->__bits[i];
 }
 
 #define CPU_XOR_S(siz, dst, src1, src2) __cpuset_xor_s (siz, dst, src1, src2)
-static inline void
+static __inline void
 __cpuset_xor_s (size_t siz, cpu_set_t *dst, cpu_set_t *src1, cpu_set_t *src2)
 {
-  for (int i = 0; i < siz / sizeof (__cpu_mask); i++)
+  int i;
+  for (i = 0; i < siz / sizeof (__cpu_mask); i++)
     (dst)->__bits[i] = (src1)->__bits[i] ^ (src2)->__bits[i];
 }
 
 #define CPU_EQUAL_S(siz, src1, src2) __cpuset_equal_s (siz, src1, src2)
-static inline int
+static __inline int
 __cpuset_equal_s (size_t siz, cpu_set_t *src1, cpu_set_t *src2)
 {
-  int res = 1;
-  for (int i = 0; res && i < siz / sizeof (__cpu_mask); i++)
+  int i, res = 1;
+  for (i = 0; res && i < siz / sizeof (__cpu_mask); i++)
     res &= (src1)->__bits[i] == (src2)->__bits[i];
   return res;
 }

--- a/winsup/cygwin/release/3.4.7
+++ b/winsup/cygwin/release/3.4.7
@@ -25,3 +25,6 @@ Bug Fixes
 - Fix return code and errno set by renameat2, if oldfile and newfile
   refer to the same file, and the RENAME_NOREPLACE flag is set.
   Addresses: https://cygwin.com/pipermail/cygwin/2023-April/253514.html
+
+- Make <sys/cpuset.h> safe for c89 compilations.
+  Addresses: https://cygwin.com/pipermail/cygwin-patches/2023q3/012308.html


### PR DESCRIPTION
This fixes regressions in 3.4.7 and fixes the build for libuv and glib for example
