### PR TITLE
Backports to fix build of dumper.exe

### DIFF
--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -115,10 +115,12 @@ AM_CONDITIONAL(CROSS_BOOTSTRAP, [test "x$with_cross_bootstrap" != "xyes"])
 
 AC_EXEEXT
 
-AC_CHECK_LIB([bfd], [bfd_init], [true],
-	     AC_MSG_WARN([Not building dumper.exe since some required libraries or headers are missing]))
+AC_ARG_ENABLE([dumper],
+	      [AS_HELP_STRING([--disable-dumper], [do not build the 'dumper' utility])],
+	      [build_dumper=$enableval],
+	      [build_dumper=yes])
 
-AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
+AM_CONDITIONAL(BUILD_DUMPER, [test "x$build_dumper" = "xyes"])
 
 # libbfd.a doesn't have a pkgconfig file, so we guess what it's dependencies
 # are, based on what's present in the build environment

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -127,6 +127,11 @@ AC_CHECK_LIB([sframe], [sframe_decode], [BFD_LIBS="${BFD_LIBS} -lsframe"])
 AC_CHECK_LIB([zstd], [ZSTD_isError], [BFD_LIBS="${BFD_LIBS} -lzstd"])
 AC_SUBST([BFD_LIBS])
 
+AC_CHECK_LIB([sframe], [sframe_decode],
+	     AC_MSG_NOTICE([Detected libsframe; Assuming that libbfd depends on it]), [true])
+
+AM_CONDITIONAL(HAVE_LIBSFRAME, [test "x$ac_cv_lib_sframe_sframe_decode" = "xyes"])
+
 AC_CONFIG_FILES([
     Makefile
     cygwin/Makefile

--- a/winsup/utils/Makefile.am
+++ b/winsup/utils/Makefile.am
@@ -88,6 +88,10 @@ profiler_CXXFLAGS = -I$(srcdir) -idirafter ${top_srcdir}/cygwin/local_includes -
 profiler_LDADD = $(LDADD) -lntdll
 cygps_LDADD = $(LDADD) -lpsapi -lntdll
 
+if HAVE_LIBSFRAME
+dumper_LDADD += -lsframe
+endif
+
 if CROSS_BOOTSTRAP
 SUBDIRS = mingw
 endif


### PR DESCRIPTION
this cherry-picks some commits from main to get dumper.exe to build again after the recent binutils changes:

* https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=89f930a9649ed9e419c7d8b2372c684313069a5b
* https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=1b5fc91a1daa90fb955f57937f4590c5079dd161