### PR TITLE
CI: fix the build with gcc 13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,11 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: |
+          # XXX: cygwin still uses gcc v11 so we get new warnings with v13,
+          # resulting in errors. We can't selectively disable warnigns since our
+          # cross compiler is also too old and doesn't understand the new
+          # warning flags, so we need to disable all errors for now.
+          export CXXFLAGS="-Wno-error -Wno-narrowing"
           (cd winsup && ./autogen.sh)
           ./configure --disable-dependency-tracking
           make -j8


### PR DESCRIPTION
cygwin still uses gcc v11 so we get new warnings with v13,
resulting in errors. We can't selectively disable warnigns since our
cross compiler is also too old and doesn't understand the new
warning flags, so we need to disable all errors for now.