### PR TITLE
path-conversion: introduce ability to switch off conversion.

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -341,6 +341,14 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
 
     if (*it == '\0' || it == end) return NONE;
 
+    /*
+     * Skip path mangling when environment indicates it.
+     */
+    const char *no_pathconv = getenv ("MSYS_NO_PATHCONV");
+
+    if (no_pathconv)
+      return NONE;
+
     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;


### PR DESCRIPTION
When calling windows native apps from MSYS2, the runtime tries to convert commandline arguments by a specific set of rules. This idea was inherited from the MSys/MinGW project (which is now seemingly stale, yet must be credited with championing this useful feature, see MinGW wiki https://web.archive.org/web/20201112005258/http://www.mingw.org/wiki/Posix_path_conversion).

If the user does not want that behavior on a big scale, e.g. inside a Bash script, with the changes introduced in this commit, the user can now set the the environment variable `MSYS_NO_PATHCONV` when calling native windows commands.

This is a feature that has been introduced in Git for Windows already in 2015 (read: a _loooong_ time ago) via https://github.com/git-for-windows/msys2-runtime/pull/11 and it predates support for the `MSYS2_ENV_CONV_EXCL` and `MSYS2_ARG_CONV_EXCL` environment variables in the MSYS2 runtime; Many users find the simplicity of `MSYS_NO_PATHCONV` appealing.

Git for Windows users have grown accustomed to the convenience of setting `MSYS_NO_PATHCONV`, and MSYS2 users are likely to enjoy it, too, so let's teach MSYS2 proper this simple trick that still allows using the sophisticated `MSYS2_*_CONV_EXCL` facilities but also offers a convenient catch-all "just don't convert anything" knob.

This PR is part of the effort described in https://github.com/msys2/MINGW-packages/discussions/16383.