### PR TITLE
Backport Git for Windows' pathconv adjustments

### DIFF
--- a/newlib/libc/stdlib/mbtowc_r.c
+++ b/newlib/libc/stdlib/mbtowc_r.c
@@ -36,7 +36,7 @@ __ascii_mbtowc (struct _reent *r,
   if (n == 0)
     return -2;
 
-#ifdef __CYGWIN__
+#ifdef STRICTLY_7BIT_ASCII
   if ((wchar_t)*t >= 0x80)
     {
       _REENT_ERRNO(r) = EILSEQ;

--- a/newlib/libc/stdlib/wctomb_r.c
+++ b/newlib/libc/stdlib/wctomb_r.c
@@ -29,7 +29,7 @@ __ascii_wctomb (struct _reent *r,
   if (s == NULL)
     return 0;
  
-#ifdef __CYGWIN__
+#ifdef STRICTLY_7BIT_ASCII
   if ((size_t)wchar >= 0x80)
 #else
   if ((size_t)wchar >= 0x100)

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -356,6 +356,12 @@ skip_p2w:
         return NONE;
     }
 
+    /*
+     * Prevent Git's :file.txt and :/message syntax from beeing modified.
+     */
+    if (*it == ':')
+        goto skip_p2w;
+
     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -389,6 +389,10 @@ skip_p2w:
                     goto skip_p2w;
             }
             break;
+        case '@':
+            // Paths do not contain '@@'
+            if (it + 1 < end && it[1] == '@')
+                goto skip_p2w;
         }
         ++it;
     }

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -380,6 +380,14 @@ skip_p2w:
             // Avoid mangling IPv6 addresses
             if (it + 1 < end && it[1] == ':')
                 goto skip_p2w;
+
+            // Leave Git's <rev>:./name syntax alone
+            if (it + 1 < end && it[1] == '.') {
+                if (it + 2 < end && it[2] == '/')
+                    goto skip_p2w;
+                if (it + 3 < end && it[2] == '.' && it[3] == '/')
+                    goto skip_p2w;
+            }
             break;
         }
         ++it;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -372,6 +372,10 @@ skip_p2w:
         case '[':
         case ']':
             goto skip_p2w;
+        case '/':
+            if (it + 1 < end && it[1] == '~')
+                goto skip_p2w;
+            break;
         }
         ++it;
     }

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -349,6 +349,13 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
     if (no_pathconv)
       return NONE;
 
+    /* Let's not convert ~/.file to ~C:\msys64\.file */
+    if (*it == '~') {
+skip_p2w:
+        *src = end;
+        return NONE;
+    }
+
     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -362,6 +362,21 @@ skip_p2w:
     if (*it == ':')
         goto skip_p2w;
 
+    while (it != end && *it) {
+        switch (*it) {
+        case '`':
+        case '\'':
+        case '"':
+        case '*':
+        case '?':
+        case '[':
+        case ']':
+            goto skip_p2w;
+        }
+        ++it;
+    }
+    it = *src;
+
     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -376,6 +376,11 @@ skip_p2w:
             if (it + 1 < end && it[1] == '~')
                 goto skip_p2w;
             break;
+        case ':':
+            // Avoid mangling IPv6 addresses
+            if (it + 1 < end && it[1] == ':')
+                goto skip_p2w;
+            break;
         }
         ++it;
     }

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -470,6 +470,8 @@ skip_p2w:
 
     int starts_with_minus = 0;
     int starts_with_minus_alpha = 0;
+    int only_dots = *it == '.';
+    int has_slashes = 0;
     if (*it == '-') {
       starts_with_minus = 1;
       it += 1;
@@ -513,11 +515,17 @@ skip_p2w:
                 if (ch == '/' && *(it2 + 1) == '/') {
                     return URL;
                 } else {
+                    if (!only_dots && !has_slashes)
+                        goto skip_p2w;
                     return POSIX_PATH_LIST;
                 }
             } else if (memchr(it2, '=', end - it2) == NULL) {
                 return SIMPLE_WINDOWS_PATH;
             }
+        } else if (ch != '.') {
+            only_dots = 0;
+            if (ch == '/' || ch == '\\')
+                has_slashes = 1;
         }
     }
 

--- a/winsup/cygwin/strfuncs.cc
+++ b/winsup/cygwin/strfuncs.cc
@@ -616,7 +616,11 @@ _sys_mbstowcs (mbtowc_p f_mbtowc, wchar_t *dst, size_t dlen, const char *src,
 	     to store them in a symmetric way. */
 	  bytes = 1;
 	  if (dst)
+#ifdef STRICTLY_7BIT_ASCII
 	    *ptr = L'\xf000' | *pmbs;
+#else
+	    *ptr = *pmbs;
+#endif
 	  memset (&ps, 0, sizeof ps);
 	}
 


### PR DESCRIPTION
This PR aligns the MSYS2 runtime with the variant that Git for Windows uses. In every commit message, the test cases of Git's test suite are listed whose expectations would not be met by the MSYS2 runtime without the respective commit.

This PR is part of my effort to address https://github.com/msys2/MINGW-packages/discussions/16383.