### PR TITLE
fixup! CI: fix the build with gcc 13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,10 +21,8 @@ jobs:
         shell: msys2 {0}
         run: |
           # XXX: cygwin still uses gcc v11 so we get new warnings with v13,
-          # resulting in errors. We can't selectively disable warnigns since our
-          # cross compiler is also too old and doesn't understand the new
-          # warning flags, so we need to disable all errors for now.
-          export CXXFLAGS="-Wno-error -Wno-narrowing"
+          # resulting in errors due to -Werror. Disable them for now.
+          export CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=array-bounds -Wno-error=overloaded-virtual -Wno-narrowing -Wno-use-after-free"
           (cd winsup && ./autogen.sh)
           ./configure --disable-dependency-tracking
           make -j8


### PR DESCRIPTION
We've upgraded our cross compiler to gcc 13 now, so the workaround can be removed