### PR TITLE
Prevent different MSYS2 runtime versions from sharing cygheaps

### DIFF
--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -65,24 +65,30 @@ AC_ARG_WITH([msys2-runtime-commit],
 case "$MSYS2_RUNTIME_COMMIT" in
 no)
     MSYS2_RUNTIME_COMMIT=
+    MSYS2_RUNTIME_COMMIT_SHORT=
     MSYS2_RUNTIME_COMMIT_HEX=0
     ;;
 yes|auto)
     if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
     then
-        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+        MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
+        MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
     else
         AC_MSG_WARN([Could not determine msys2-runtime commit"])
         MSYS2_RUNTIME_COMMIT=
+        MSYS2_RUNTIME_COMMIT_SHORT=
         MSYS2_RUNTIME_COMMIT_HEX=0
     fi
     ;;
 *)
     expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
     AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
-    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+    MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
+    MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
     ;;
 esac
+AC_SUBST(MSYS2_RUNTIME_COMMIT)
+AC_SUBST(MSYS2_RUNTIME_COMMIT_SHORT)
 AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
 
 AC_ARG_ENABLE(debugging,

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -57,6 +57,34 @@ AC_CHECK_TOOL(RANLIB, ranlib, ranlib)
 AC_CHECK_TOOL(STRIP, strip, strip)
 AC_CHECK_TOOL(WINDRES, windres, windres)
 
+# Record msys2-runtime commit
+AC_ARG_WITH([msys2-runtime-commit],
+  [AS_HELP_STRING([--with-msys2-runtime-commit=COMMIT],
+		  [indicate the msys2-runtime commit corresponding to this build])],
+  [MSYS2_RUNTIME_COMMIT=$withval], [MSYS2_RUNTIME_COMMIT=yes])
+case "$MSYS2_RUNTIME_COMMIT" in
+no)
+    MSYS2_RUNTIME_COMMIT=
+    MSYS2_RUNTIME_COMMIT_HEX=0
+    ;;
+yes|auto)
+    if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
+    then
+        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+    else
+        AC_MSG_WARN([Could not determine msys2-runtime commit"])
+        MSYS2_RUNTIME_COMMIT=
+        MSYS2_RUNTIME_COMMIT_HEX=0
+    fi
+    ;;
+*)
+    expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
+    AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
+    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+    ;;
+esac
+AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
+
 AC_ARG_ENABLE(debugging,
 [AS_HELP_STRING([--enable-debugging],[Build a cygwin DLL which has more consistency checking for debugging])],
 [case "${enableval}" in

--- a/winsup/cygwin/Makefile.am
+++ b/winsup/cygwin/Makefile.am
@@ -17,6 +17,9 @@ if TARGET_X86_64
 COMMON_CFLAGS+=-mcmodel=small
 endif
 
+VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
+COMMON_CFLAGS += $(VERSION_CFLAGS)
+
 AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
 AM_CXXFLAGS=$(cxxflags_common) $(COMMON_CFLAGS) -fno-threadsafe-statics
 

--- a/winsup/cygwin/Makefile.am
+++ b/winsup/cygwin/Makefile.am
@@ -17,7 +17,9 @@ if TARGET_X86_64
 COMMON_CFLAGS+=-mcmodel=small
 endif
 
-VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
+VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT="\"@MSYS2_RUNTIME_COMMIT@\""
+VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_SHORT="\"@MSYS2_RUNTIME_COMMIT_SHORT@\""
+VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
 COMMON_CFLAGS += $(VERSION_CFLAGS)
 
 AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
@@ -442,7 +444,7 @@ uname_version.c: .FORCE
 version.cc: scripts/mkvers.sh include/cygwin/version.h winver.rc $(src_files)
 	@echo "Making version.cc and winver.o";\
 	export CC="$(CC)";\
-	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS)
+	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS) $(VERSION_CFLAGS)
 
 winver.o: version.cc
 

--- a/winsup/cygwin/dcrt0.cc
+++ b/winsup/cygwin/dcrt0.cc
@@ -530,7 +530,7 @@ get_cygwin_startup_info ()
   child_info *res = (child_info *) si.lpReserved2;
 
   if (si.cbReserved2 < EXEC_MAGIC_SIZE || !res
-      || res->intro != PROC_MAGIC_GENERIC || res->magic != CHILD_INFO_MAGIC)
+      || res->intro != PROC_MAGIC_GENERIC || res->magic != (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX))
     {
       strace.activate (false);
       res = NULL;

--- a/winsup/cygwin/scripts/mkvers.sh
+++ b/winsup/cygwin/scripts/mkvers.sh
@@ -16,6 +16,7 @@ incfile="$1"; shift
 rcfile="$1"; shift
 windres="$1"; shift
 iflags=
+msys2_runtime_commit=
 # Find header file locations
 while [ -n "$*" ]; do
   case "$1" in
@@ -26,6 +27,9 @@ while [ -n "$*" ]; do
     shift
     iflags="$iflags -I$1"
       ;;
+  -DMSYS2_RUNTIME_COMMIT=*)
+    msys2_runtime_commit="${1#*=}"
+    ;;
   esac
   shift
 done
@@ -167,6 +171,10 @@ if [ -n "$cvs_tag" ]
 then
   cvs_tag="$(echo $wv_cvs_tag | sed -e 's/-branch.*//')"
   cygwin_ver="$cygwin_ver-$cvs_tag"
+fi
+if [ -n "$msys2_runtime_commit" ]
+then
+  cygwin_ver="$cygwin_ver-$msys2_runtime_commit"
 fi
 
 echo "Version $cygwin_ver"

--- a/winsup/cygwin/sigproc.cc
+++ b/winsup/cygwin/sigproc.cc
@@ -811,7 +811,7 @@ int child_info::retry_count = 0;
 child_info::child_info (unsigned in_cb, child_info_types chtype,
 			bool need_subproc_ready):
   msv_count (0), cb (in_cb), intro (PROC_MAGIC_GENERIC),
-  magic (CHILD_INFO_MAGIC), type (chtype), cygheap (::cygheap),
+  magic (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX), type (chtype), cygheap (::cygheap),
   cygheap_max (::cygheap_max), flag (0), retry (child_info::retry_count),
   rd_proc_pipe (NULL), wr_proc_pipe (NULL), sigmask (_my_tls.sigmask)
 {

--- a/winsup/cygwin/uname.cc
+++ b/winsup/cygwin/uname.cc
@@ -76,18 +76,19 @@ uname_x (struct utsname *name)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation="
 #ifdef CYGPORT_RELEASE_INFO
-      snprintf (name->release, _UTSNAME_LENGTH, "%s.%s",
-		__XSTRING (CYGPORT_RELEASE_INFO), name->machine);
+      snprintf (name->release, _UTSNAME_LENGTH, "%s-%s.%s",
+		__XSTRING (CYGPORT_RELEASE_INFO), MSYS2_RUNTIME_COMMIT_SHORT, name->machine);
 #else
       extern const char *uname_dev_version;
       if (uname_dev_version && uname_dev_version[0])
-	snprintf (name->release, _UTSNAME_LENGTH, "%s.%s",
-		  uname_dev_version, name->machine);
+	snprintf (name->release, _UTSNAME_LENGTH, "%s-%s.%s",
+		  uname_dev_version, MSYS2_RUNTIME_COMMIT_SHORT, name->machine);
       else
-	__small_sprintf (name->release, "%d.%d.%d-api-%d.%s",
+	__small_sprintf (name->release, "%d.%d.%d-%s-api-%d.%s",
 			 cygwin_version.dll_major / 1000,
 			 cygwin_version.dll_major % 1000,
 			 cygwin_version.dll_minor,
+			 MSYS2_RUNTIME_COMMIT_SHORT,
 			 cygwin_version.api_minor,
 			 name->machine);
 #endif
@@ -129,14 +130,15 @@ uname (struct utsname *in_name)
       cygwin_gethostname (name->nodename, sizeof (name->nodename) - 1);
 
       /* Cygwin dll release */
-      __small_sprintf (name->release, "%d.%d.%d(%d.%d/%d/%d)",
+      __small_sprintf (name->release, "%d.%d.%d(%d.%d/%d/%d/%s)",
 		       cygwin_version.dll_major / 1000,
 		       cygwin_version.dll_major % 1000,
 		       cygwin_version.dll_minor,
 		       cygwin_version.api_major,
 		       cygwin_version.api_minor,
 		       cygwin_version.shared_data,
-		       cygwin_version.mount_registry);
+		       cygwin_version.mount_registry,
+		       MSYS2_RUNTIME_COMMIT_SHORT);
 
       /* Cygwin "version" aka build date */
       strcpy (name->version, cygwin_version.dll_build_date);


### PR DESCRIPTION
This allows users to run Cygwin programs from an MSYS2 Bash even when the MSYS2 runtime version corresponds to the Cygwin runtime version used by those Cygwin programs.

Incidentally, it also allows calling Git for Windows' Bash from the MSYS2 Bash.