### PR TITLE
msys2-3.3.6: backports from 3.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,11 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: |
+          # XXX: cygwin still uses gcc v11 so we get new warnings with v13,
+          # resulting in errors. We can't selectively disable warnigns since our
+          # cross compiler is also too old and doesn't understand the new
+          # warning flags, so we need to disable all errors for now.
+          export CXXFLAGS="-Wno-error -Wno-narrowing"
           (cd winsup && ./autogen.sh)
           ./configure --disable-dependency-tracking
           make -j8

--- a/winsup/cygwin/fhandler_console.cc
+++ b/winsup/cygwin/fhandler_console.cc
@@ -937,7 +937,11 @@ fhandler_console::send_winch_maybe ()
       con.scroll_region.Bottom = -1;
       if (wincap.has_con_24bit_colors () && !con_is_legacy)
 	fix_tab_position (get_output_handle ());
+      /* longjmp() may be called in the signal handler like less,
+	 so release input_mutex temporarily before kill_pgrp(). */
+      release_input_mutex ();
       get_ttyp ()->kill_pgrp (SIGWINCH);
+      acquire_input_mutex (mutex_timeout);
       return true;
     }
   return false;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -346,6 +346,13 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
 
     path_type result = NONE;
 
+    if (it + 1 == end) {
+        switch (*it) {
+        case '/':   return ROOTED_PATH ;
+        default:    return SIMPLE_WINDOWS_PATH;
+        }
+    }
+
     if (isalpha(*it) && *(it + 1) == ':') {
         if (*(it + 2) == '\\') {
             return SIMPLE_WINDOWS_PATH;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -428,7 +428,7 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
             if (isalpha(ch) && (*(it2+1) == ':') && (*(it2+2) == '/')) {
                 return SIMPLE_WINDOWS_PATH;
             }
-            if (ch == '/'&& memchr(it2, ',', end - it) == NULL) {
+            if (ch == '/'&& memchr(it2, ',', end - it2) == NULL) {
                 *src = it2;
                 return find_path_start_and_type(src, true, end);
             }
@@ -455,7 +455,7 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
                 } else {
                     return POSIX_PATH_LIST;
                 }
-            } else if (memchr(it2, '=', end - it) == NULL) {
+            } else if (memchr(it2, '=', end - it2) == NULL) {
                 return SIMPLE_WINDOWS_PATH;
             }
         }

--- a/winsup/cygwin/nlsfuncs.cc
+++ b/winsup/cygwin/nlsfuncs.cc
@@ -255,8 +255,13 @@ rebase_locale_buf (const void *ptrv, const void *ptrvend, const char *newbase,
 {
   const char **ptrsend = (const char **) ptrvend;
   for (const char **ptrs = (const char **) ptrv; ptrs < ptrsend; ++ptrs)
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
     if (*ptrs >= oldbase && *ptrs < oldend)
       *ptrs += newbase - oldbase;
+#pragma GCC diagnostic pop
 }
 
 static wchar_t *
@@ -613,10 +618,15 @@ __set_lc_time_from_win (const char *name,
 		era = NULL;
 	      else
 		{
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
 		  if (tmp != new_lc_time_buf)
 		    rebase_locale_buf (_time_locale, _time_locale + 1, tmp,
 				       new_lc_time_buf, lc_time_ptr);
 		  lc_time_ptr = tmp + (lc_time_ptr - new_lc_time_buf);
+#pragma GCC diagnostic pop
 		  new_lc_time_buf = tmp;
 		  lc_time_end = new_lc_time_buf + len;
 		}
@@ -675,9 +685,14 @@ __set_lc_time_from_win (const char *name,
       free (new_lc_time_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_time_buf)
     rebase_locale_buf (_time_locale, _time_locale + 1, tmp,
 		       new_lc_time_buf, lc_time_ptr);
+#pragma GCC diagnostic pop
   *lc_time_buf = tmp;
   return 1;
 }
@@ -747,9 +762,14 @@ __set_lc_ctype_from_win (const char *name,
       free (new_lc_ctype_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_ctype_buf)
     rebase_locale_buf (_ctype_locale, _ctype_locale + 1, tmp,
 		       new_lc_ctype_buf, lc_ctype_ptr);
+#pragma GCC diagnostic pop
   *lc_ctype_buf = tmp;
   return 1;
 }
@@ -822,9 +842,14 @@ __set_lc_numeric_from_win (const char *name,
       free (new_lc_numeric_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_numeric_buf)
     rebase_locale_buf (_numeric_locale, _numeric_locale + 1, tmp,
 		       new_lc_numeric_buf, lc_numeric_ptr);
+#pragma GCC diagnostic pop
   *lc_numeric_buf = tmp;
   return 1;
 }
@@ -959,9 +984,14 @@ __set_lc_monetary_from_win (const char *name,
       free (new_lc_monetary_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_monetary_buf)
     rebase_locale_buf (_monetary_locale, _monetary_locale + 1, tmp,
 		       new_lc_monetary_buf, lc_monetary_ptr);
+#pragma GCC diagnostic pop
   *lc_monetary_buf = tmp;
   return 1;
 }

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -4873,10 +4873,24 @@ find_fast_cwd_pointer ()
 	     or, then `mov %r12,%rcx', then `callq RtlEnterCriticalSection'. */
 	  lock = (const uint8_t *) memmem ((const char *) use_cwd, 80,
 					   "\x4c\x8d\x25", 3);
-	  if (!lock)
-	    return NULL;
 	  call_rtl_offset = 14;
 	}
+
+      if (!lock)
+	{
+	  /* A recent Windows Preview calls `lea rel(rip),%r13' then
+	     some unrelated instructions, then `callq RtlEnterCriticalSection'.
+	     */
+	  lock = (const uint8_t *) memmem ((const char *) use_cwd, 80,
+					   "\x4c\x8d\x2d", 3);
+	  call_rtl_offset = 24;
+	}
+
+      if (!lock)
+	{
+	  return NULL;
+	}
+
       PRTL_CRITICAL_SECTION lockaddr =
         (PRTL_CRITICAL_SECTION) (lock + 7 + peek32 (lock + 3));
       /* Test if lock address is FastPebLock. */


### PR DESCRIPTION
As pointed out by @jeremyd2019 in https://github.com/git-for-windows/msys2-runtime/pull/61#issuecomment-1937088400, the backports I did in Git for Windows are also desirable here, even if MSYS2 is not half as reliant on v3.3.* as Git for Windows is (because it needs to [support 32-bit builds until 2029](https://gitforwindows.org/32-bit.html)).