### PR TITLE
msys2 3.3.6 binutils fixes

### DIFF
--- a/include/ansidecl.h
+++ b/include/ansidecl.h
@@ -283,6 +283,49 @@ So instead we use the macro below and test it against specific values.  */
 # endif /* GNUC >= 4.9 */
 #endif /* ATTRIBUTE_NO_SANITIZE_UNDEFINED */
 
+/* Attribute 'nonstring' was valid as of gcc 8.  */
+#ifndef ATTRIBUTE_NONSTRING
+# if GCC_VERSION >= 8000
+#  define ATTRIBUTE_NONSTRING __attribute__ ((__nonstring__))
+# else
+#  define ATTRIBUTE_NONSTRING
+# endif
+#endif
+
+/* Attribute `alloc_size' was valid as of gcc 4.3.  */
+#ifndef ATTRIBUTE_RESULT_SIZE_1
+# if (GCC_VERSION >= 4003)
+#  define ATTRIBUTE_RESULT_SIZE_1 __attribute__ ((alloc_size (1)))
+# else
+#  define ATTRIBUTE_RESULT_SIZE_1
+#endif
+#endif
+
+#ifndef ATTRIBUTE_RESULT_SIZE_2
+# if (GCC_VERSION >= 4003)
+#  define ATTRIBUTE_RESULT_SIZE_2 __attribute__ ((alloc_size (2)))
+# else
+#  define ATTRIBUTE_RESULT_SIZE_2
+#endif
+#endif
+
+#ifndef ATTRIBUTE_RESULT_SIZE_1_2
+# if (GCC_VERSION >= 4003)
+#  define ATTRIBUTE_RESULT_SIZE_1_2 __attribute__ ((alloc_size (1, 2)))
+# else
+#  define ATTRIBUTE_RESULT_SIZE_1_2
+#endif
+#endif
+
+/* Attribute `warn_unused_result' was valid as of gcc 3.3.  */
+#ifndef ATTRIBUTE_WARN_UNUSED_RESULT
+# if GCC_VERSION >= 3003
+#  define ATTRIBUTE_WARN_UNUSED_RESULT __attribute__ ((__warn_unused_result__))
+# else
+#  define ATTRIBUTE_WARN_UNUSED_RESULT
+# endif
+#endif
+
 /* We use __extension__ in some places to suppress -pedantic warnings
    about GCC extensions.  This feature didn't work properly before
    gcc 2.8.  */

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -110,10 +110,12 @@ AC_CHECK_LIB([bfd], [bfd_init], [true],
 
 AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
 
-AC_CHECK_LIB([sframe], [sframe_decode],
-	     AC_MSG_NOTICE([Detected libsframe; Assuming that libbfd depends on it]), [true])
-
-AM_CONDITIONAL(HAVE_LIBSFRAME, [test "x$ac_cv_lib_sframe_sframe_decode" = "xyes"])
+# libbfd.a doesn't have a pkgconfig file, so we guess what it's dependencies
+# are, based on what's present in the build environment
+BFD_LIBS="-lintl -liconv -liberty -lz"
+AC_CHECK_LIB([sframe], [sframe_decode], [BFD_LIBS="${BFD_LIBS} -lsframe"])
+AC_CHECK_LIB([zstd], [ZSTD_isError], [BFD_LIBS="${BFD_LIBS} -lzstd"])
+AC_SUBST([BFD_LIBS])
 
 AC_CONFIG_FILES([
     Makefile

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -105,10 +105,12 @@ AM_CONDITIONAL(CROSS_BOOTSTRAP, [test "x$with_cross_bootstrap" != "xyes"])
 
 AC_EXEEXT
 
-AC_CHECK_LIB([bfd], [bfd_init], [true],
-	     AC_MSG_WARN([Not building dumper.exe since some required libraries or headers are missing]))
+AC_ARG_ENABLE([dumper],
+	      [AS_HELP_STRING([--disable-dumper], [do not build the 'dumper' utility])],
+	      [build_dumper=$enableval],
+	      [build_dumper=yes])
 
-AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
+AM_CONDITIONAL(BUILD_DUMPER, [test "x$build_dumper" = "xyes"])
 
 # libbfd.a doesn't have a pkgconfig file, so we guess what it's dependencies
 # are, based on what's present in the build environment

--- a/winsup/cygwin/cygwin.sc.in
+++ b/winsup/cygwin/cygwin.sc.in
@@ -142,10 +142,10 @@ SECTIONS
   {
     *(.rsrc)
     *(SORT(.rsrc$*))
-    _SYM (_cygheap_start) = .;
   }
   .cygheap ALIGN(__section_alignment__) :
   {
+    _SYM (_cygheap_start) = .;
 #ifdef __x86_64__
     . = . + (3072 * 1024);
 #else

--- a/winsup/utils/Makefile.am
+++ b/winsup/utils/Makefile.am
@@ -78,7 +78,8 @@ LDADD = -lnetapi32
 cygpath_CXXFLAGS = -fno-threadsafe-statics $(AM_CXXFLAGS)
 cygpath_LDADD = $(LDADD) -luserenv -lntdll
 dumper_CXXFLAGS = -I$(top_srcdir)/../include $(AM_CXXFLAGS)
-dumper_LDADD = $(LDADD) -lpsapi -lbfd -lintl -liconv -liberty -lz -lntdll
+dumper_LDADD = $(LDADD) -lpsapi -lntdll -lbfd @BFD_LIBS@
+dumper_LDFLAGS =
 ldd_LDADD = $(LDADD) -lpsapi -lntdll
 mount_CXXFLAGS = -DFSTAB_ONLY $(AM_CXXFLAGS)
 minidumper_LDADD = $(LDADD) -ldbghelp
@@ -86,10 +87,6 @@ pldd_LDADD = $(LDADD) -lpsapi
 profiler_CXXFLAGS = -I$(srcdir) -idirafter ${top_srcdir}/cygwin -idirafter ${top_srcdir}/cygwin/include $(AM_CXXFLAGS)
 profiler_LDADD = $(LDADD) -lntdll
 cygps_LDADD = $(LDADD) -lpsapi -lntdll
-
-if HAVE_LIBSFRAME
-dumper_LDADD += -lsframe
-endif
 
 if CROSS_BOOTSTRAP
 SUBDIRS = mingw


### PR DESCRIPTION
Fixes #200

Wound up having to backport more fixes for binutils than I expected, to get dumper.exe included again.

Corinna suggested in https://cygwin.com/pipermail/cygwin/2024-February/255472.html that there was probably no good reason for `_cygheap_start` being in `.rsrc` instead of `.cygheap` section, so moved it.  This at least works well enough to run and update other packages on both i686 and x86_64, so is definitely an improvement on the old behavior of crashing immediately.

As I mentioned in the commit message, this may result in reducing the difference between `_cygheap_start` and `_cygheap_end` by the fraction of a page not used in the `.rsrc` section.  This works out to moving `_cygheap_start` forward by 3064 bytes on i686, from 0x408 bytes into the `.rsrc` page to the start of the `.cygheap` section, which should have reduced the difference between `_cygheap_end` and `_cygheap_start` from 2137080 to 2134016 bytes.  But for some reason, in practice this difference is now 2138112 bytes.

On x86_64, the used portion of `.rsrc` is also `0x408` bytes, and the difference between end and start went from 3210232 to 3182592 bytes.