### PR TITLE
Support OneDrive better

### DIFF
--- a/winsup/cygwin/autoload.cc
+++ b/winsup/cygwin/autoload.cc
@@ -477,6 +477,7 @@ LoadDLLfuncEx (SetThreadDescription, 8, KernelBase, 1)
 LoadDLLfunc (VirtualAlloc2, 28, KernelBase)
 
 LoadDLLfunc (NtMapViewOfSectionEx, 36, ntdll)
+LoadDLLfuncEx (RtlSetProcessPlaceholderCompatibilityMode, 4, ntdll, 1)
 
 LoadDLLfunc (ldap_bind_s, 0, wldap32)
 LoadDLLfunc (ldap_count_entries, 0, wldap32)

--- a/winsup/cygwin/dcrt0.cc
+++ b/winsup/cygwin/dcrt0.cc
@@ -821,6 +821,9 @@ dll_crt0_1 (void *)
   if (dynamically_loaded)
     sigproc_init ();
 
+  /* Call this before accessing any files. */
+  RtlSetProcessPlaceholderCompatibilityMode (PHCM_EXPOSE_PLACEHOLDERS);
+
   check_sanity_and_sync (user_data);
 
   /* Initialize malloc and then call user_shared_initialize since it relies

--- a/winsup/cygwin/local_includes/ntdll.h
+++ b/winsup/cygwin/local_includes/ntdll.h
@@ -159,6 +159,13 @@ extern GUID __cygwin_socket_guid;
 #define FILE_VC_QUOTAS_REBUILDING       0x00000200
 #define FILE_VC_VALID_MASK              0x000003ff
 
+#define PHCM_APPLICATION_DEFAULT	 0
+#define PHCM_DISGUISE_PLACEHOLDER	 1
+#define PHCM_EXPOSE_PLACEHOLDERS	 2
+#define PHCM_MAX			 2
+#define PHCM_ERROR_INVALID_PARAMETER	-1
+#define PHCM_ERROR_NO_TEB		-2
+
 /* IOCTL code to impersonate client of named pipe. */
 
 #define FSCTL_PIPE_DISCONNECT	CTL_CODE(FILE_DEVICE_NAMED_PIPE, 1, \
@@ -1605,6 +1612,7 @@ extern "C"
 					 BOOLEAN);
   NTSTATUS RtlSetGroupSecurityDescriptor (PSECURITY_DESCRIPTOR, PSID, BOOLEAN);
   NTSTATUS RtlSetOwnerSecurityDescriptor (PSECURITY_DESCRIPTOR, PSID, BOOLEAN);
+  CHAR RtlSetProcessPlaceholderCompatibilityMode (CHAR);
   PUCHAR RtlSubAuthorityCountSid (PSID);
   PULONG RtlSubAuthoritySid (PSID, ULONG);
   ULONG RtlUnicodeStringToAnsiSize (PUNICODE_STRING);

--- a/winsup/cygwin/local_includes/path.h
+++ b/winsup/cygwin/local_includes/path.h
@@ -23,6 +23,14 @@ has_attribute (DWORD attributes, DWORD attribs_to_test)
 	 && (attributes & attribs_to_test);
 }
 
+extern inline bool
+isoffline (DWORD attributes)
+{
+  return has_attribute (attributes, FILE_ATTRIBUTE_OFFLINE
+				    | FILE_ATTRIBUTE_RECALL_ON_OPEN
+				    | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS);
+}
+
 enum executable_states
 {
   is_executable,
@@ -230,6 +238,12 @@ class path_conv
   bool exists () const {return fileattr != INVALID_FILE_ATTRIBUTES;}
   bool has_attribute (DWORD x) const {return exists () && (fileattr & x);}
   int isdir () const {return has_attribute (FILE_ATTRIBUTE_DIRECTORY);}
+  bool isoffline () const
+  {
+    return has_attribute (FILE_ATTRIBUTE_OFFLINE
+			  | FILE_ATTRIBUTE_RECALL_ON_OPEN
+			  | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS);
+  }
   executable_states exec_state ()
   {
     extern int _check_for_executable;
@@ -237,7 +251,7 @@ class path_conv
       return is_executable;
     if (mount_flags & MOUNT_NOTEXEC)
       return not_executable;
-    if (!_check_for_executable)
+    if (isoffline () || !_check_for_executable)
       return dont_care_if_executable;
     return dont_know_if_executable;
   }

--- a/winsup/cygwin/local_includes/winlean.h
+++ b/winsup/cygwin/local_includes/winlean.h
@@ -74,6 +74,14 @@ details. */
 #undef CRITICAL
 #endif
 
+/* Filesystem flags not yet supported by Mingw-w64 headers. */
+#ifndef FILE_ATTRIBUTE_RECALL_ON_OPEN
+#define FILE_ATTRIBUTE_RECALL_ON_OPEN		0x00040000
+#endif
+#ifndef FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+#define FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS	0x00400000
+#endif
+
 /* So-called "Microsoft Account" SIDs (S-1-11-...) have a netbios domain name
    "MicrosoftAccounts".  The new "Application Container SIDs" (S-1-15-...)
    have a netbios domain name "APPLICATION PACKAGE AUTHORITY"

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -577,6 +577,7 @@ getfileattr (const char *path, bool caseinsensitive) /* path has to be always ab
       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
 			   FILE_SYNCHRONOUS_IO_NONALERT
+			   | FILE_OPEN_NO_RECALL
 			   | FILE_OPEN_FOR_BACKUP_INTENT
 			   | FILE_DIRECTORY_FILE);
       if (NT_SUCCESS (status))
@@ -3353,7 +3354,8 @@ restart:
 	    }
 	  status = NtOpenFile (&h, READ_CONTROL | FILE_READ_ATTRIBUTES,
 			       &attr, &io, FILE_SHARE_VALID_FLAGS,
-			       FILE_OPEN_REPARSE_POINT
+			       FILE_OPEN_NO_RECALL
+			       | FILE_OPEN_REPARSE_POINT
 			       | FILE_OPEN_FOR_BACKUP_INTENT);
 	  debug_printf ("%y = NtOpenFile (no-EAs %S)", status, &upath);
 	}
@@ -3481,6 +3483,7 @@ restart:
 	      status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
 				   &dattr, &io, FILE_SHARE_VALID_FLAGS,
 				   FILE_SYNCHRONOUS_IO_NONALERT
+				   | FILE_OPEN_NO_RECALL
 				   | FILE_OPEN_FOR_BACKUP_INTENT
 				   | FILE_DIRECTORY_FILE);
 	      if (!NT_SUCCESS (status))
@@ -3570,7 +3573,11 @@ restart:
 	 directory using a relative path, symlink evaluation goes totally
 	 awry.  We never want a virtual drive evaluated as symlink. */
       if (upath.Length <= 14)
-	  goto file_not_symlink;
+	goto file_not_symlink;
+
+      /* Offline files, even if reparse points, are not symlinks. */
+      if (isoffline (fileattr))
+	goto file_not_symlink;
 
       /* Reparse points are potentially symlinks.  This check must be
 	 performed before checking the SYSTEM attribute for sysfile
@@ -3616,7 +3623,8 @@ restart:
 
 	  status = NtOpenFile (&sym_h, SYNCHRONIZE | GENERIC_READ, &attr, &io,
 			       FILE_SHARE_VALID_FLAGS,
-			       FILE_OPEN_FOR_BACKUP_INTENT
+			       FILE_OPEN_NO_RECALL
+			       | FILE_OPEN_FOR_BACKUP_INTENT
 			       | FILE_SYNCHRONOUS_IO_NONALERT);
 	  if (!NT_SUCCESS (status))
 	    res = 0;
@@ -3660,7 +3668,8 @@ restart:
 
 	  status = NtOpenFile (&sym_h, SYNCHRONIZE | GENERIC_READ, &attr, &io,
 			       FILE_SHARE_VALID_FLAGS,
-			       FILE_OPEN_FOR_BACKUP_INTENT
+			       FILE_OPEN_NO_RECALL
+			       | FILE_OPEN_FOR_BACKUP_INTENT
 			       | FILE_SYNCHRONOUS_IO_NONALERT);
 
 	  if (!NT_SUCCESS (status))

--- a/winsup/cygwin/sec/base.cc
+++ b/winsup/cygwin/sec/base.cc
@@ -65,7 +65,8 @@ get_file_sd (HANDLE fh, path_conv &pc, security_descriptor &sd,
 			   fh ? pc.init_reopen_attr (attr, fh)
 			      : pc.get_object_attr (attr, sec_none_nih),
 			   &io, FILE_SHARE_VALID_FLAGS,
-			   FILE_OPEN_FOR_BACKUP_INTENT
+			   FILE_OPEN_NO_RECALL
+			   | FILE_OPEN_FOR_BACKUP_INTENT
 			   | pc.is_known_reparse_point ()
 			   ? FILE_OPEN_REPARSE_POINT : 0);
       if (!NT_SUCCESS (status))
@@ -129,7 +130,8 @@ get_file_sd (HANDLE fh, path_conv &pc, security_descriptor &sd,
 				  NULL, NULL);
       status = NtOpenFile (&fh, READ_CONTROL, &attr, &io,
 			   FILE_SHARE_VALID_FLAGS,
-			   FILE_OPEN_FOR_BACKUP_INTENT
+			   FILE_OPEN_NO_RECALL
+			   | FILE_OPEN_FOR_BACKUP_INTENT
 			   | FILE_OPEN_REPARSE_POINT);
       if (!NT_SUCCESS (status))
 	{
@@ -234,7 +236,8 @@ set_file_sd (HANDLE fh, path_conv &pc, security_descriptor &sd, bool is_chown)
 				  : pc.get_object_attr (attr, sec_none_nih),
 			       &io,
 			       FILE_SHARE_VALID_FLAGS,
-			       FILE_OPEN_FOR_BACKUP_INTENT
+			       FILE_OPEN_NO_RECALL
+			       | FILE_OPEN_FOR_BACKUP_INTENT
 			       | pc.is_known_reparse_point ()
 			       ? FILE_OPEN_REPARSE_POINT : 0);
 	  if (!NT_SUCCESS (status))


### PR DESCRIPTION
This backports f6b56abec1865f8da7632644210bae36b395569b and 2100c6ef0dee120c316b7bea42bf5e93c281e808, avoiding to hydrate OneDrive files (or for that matter, other files marked as "offline", i.e. not-yet-downloaded), _just_ for the sake of determining whether the files are to be considered executable by inspecting the first line in case it is `#!/bin/sh`.

This fixes #206.