### PR TITLE
Backport of followup fix for "Cygwin: try to avoid recalling offline files"

### DIFF
--- a/winsup/cygwin/fhandler/disk_file.cc
+++ b/winsup/cygwin/fhandler/disk_file.cc
@@ -328,7 +328,6 @@ fhandler_base::fstat_by_name (struct stat *buf)
       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
 			   FILE_SYNCHRONOUS_IO_NONALERT
-			   | FILE_OPEN_NO_RECALL
 			   | FILE_OPEN_FOR_BACKUP_INTENT
 			   | FILE_DIRECTORY_FILE);
       if (!NT_SUCCESS (status))

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -577,7 +577,6 @@ getfileattr (const char *path, bool caseinsensitive) /* path has to be always ab
       status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
 			   &attr, &io, FILE_SHARE_VALID_FLAGS,
 			   FILE_SYNCHRONOUS_IO_NONALERT
-			   | FILE_OPEN_NO_RECALL
 			   | FILE_OPEN_FOR_BACKUP_INTENT
 			   | FILE_DIRECTORY_FILE);
       if (NT_SUCCESS (status))
@@ -3483,7 +3482,6 @@ restart:
 	      status = NtOpenFile (&dir, SYNCHRONIZE | FILE_LIST_DIRECTORY,
 				   &dattr, &io, FILE_SHARE_VALID_FLAGS,
 				   FILE_SYNCHRONOUS_IO_NONALERT
-				   | FILE_OPEN_NO_RECALL
 				   | FILE_OPEN_FOR_BACKUP_INTENT
 				   | FILE_DIRECTORY_FILE);
 	      if (!NT_SUCCESS (status))


### PR DESCRIPTION
We backported it in #209 but there is a followup regression fix upstream which we should probably backport too: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=56e7563b9aa665f35b657537e46a7feb4726f763