### PR TITLE
Recognize path lists starting with absolute or relative paths again

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -359,6 +359,18 @@ skip_p2w:
     }
 
     /*
+     * Discern between Git's `<rev>:<path>`, SCP's `<host>:<path>` pattern
+     * (which is not a path list but may naïvely look like one) on the one
+     * hand, and path lists starting with `/<path>`, `./<path>` or `../<path>`
+     * on the other hand.
+     */
+    bool potential_path_list = *it == '/' ||
+	    (*it == '.' &&
+		(it[1] == ':' || it[1] == '/' ||
+		 (it[1] == '.' &&
+			(it[2] == ':' || it[2] == '/'))));
+
+    /*
      * Prevent Git's :file.txt and :/message syntax from beeing modified.
      */
     if (*it == ':')
@@ -383,7 +395,7 @@ skip_p2w:
                 goto skip_p2w;
 
             // Leave Git's <rev>:./name syntax alone
-            if (it + 1 < end && it[1] == '.') {
+            if (!potential_path_list && it + 1 < end && it[1] == '.') {
                 if (it + 2 < end && it[2] == '/')
                     goto skip_p2w;
                 if (it + 3 < end && it[2] == '.' && it[3] == '/')


### PR DESCRIPTION
When we fixed MSYS2's automatic Unix <-> Windows path conversion to identify and skip Git-style `<rev>:<path>` arguments (and incidentally also scp-style `<host>:<path>` ones), we assumed that path lists containing relative paths would be a rare scenario.

My, was this assumption wrong!

Let's add another heuristic that detects absolute paths at the beginning of path lists, and relative ones starting with either `./` or `../`, neither of which match those Git-style nor scp-style arguments, and then prevent the detection of the latter style from kicking in.

This addresses https://github.com/msys2/msys2-runtime/issues/208