### PR TITLE
CI: set -Wno-error=maybe-uninitialized

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # XXX: cygwin still uses gcc v11 so we get new warnings with v13,
           # resulting in errors due to -Werror. Disable them for now.
-          export CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=array-bounds -Wno-error=overloaded-virtual -Wno-narrowing -Wno-use-after-free"
+          export CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=array-bounds -Wno-error=overloaded-virtual -Wno-narrowing -Wno-use-after-free -Wno-error=maybe-uninitialized"
           (cd winsup && ./autogen.sh)
           ./configure --disable-dependency-tracking
           make -j8


### PR DESCRIPTION
After the update of msys2-w32api from v11.0.1 to current master (and soon to be v12) we get: winsup/cygwin/exceptions.cc:1736:33: error: '<anonymous>' may be used uninitialized [-Werror=maybe-uninitialized]

Ignore it like the rest.

Fixes #214