### PR TITLE
[backport] Cygwin: disable high-entropy VA for ldh

### DIFF
--- a/winsup/utils/mingw/Makefile.am
+++ b/winsup/utils/mingw/Makefile.am
@@ -53,6 +53,7 @@ cygcheck_LDADD = -lz -lwininet -lshlwapi -lpsapi -lntdll
 cygwin_console_helper_SOURCES = cygwin-console-helper.cc
 
 ldh_SOURCES = ldh.cc
+ldh_LDFLAGS = ${AM_LDFLAGS} -Wl,--disable-high-entropy-va
 
 strace_SOURCES = \
 	path.cc \


### PR DESCRIPTION
If ldd is run against a DLL which links to the Cygwin DLL, ldh will end up loading the Cygwin DLL dynamically, much like cygcheck or strace.

Addresses: https://cygwin.com/pipermail/cygwin/2024-May/255991.html
Fixes: 60675f1a7eb2 ("Cygwin: decouple shared mem regions from Cygwin DLL")
Reviewed-by: Ken Brown <kbrown@cornell.edu>, Takashi Yano <takashi.yano@nifty.ne.jp>