### PR TITLE
msys2-runtime-3.4: fix build

### DIFF
--- a/winsup/cygwin/exceptions.cc
+++ b/winsup/cygwin/exceptions.cc
@@ -1646,7 +1646,10 @@ _cygtls::call_signal_handler ()
 		 context, unwind to the caller and in case we're called
 		 from sigdelayed, fix the instruction pointer accordingly. */
 	      context.uc_mcontext.ctxflags = CONTEXT_FULL;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 	      RtlCaptureContext ((PCONTEXT) &context.uc_mcontext);
+#pragma GCC diagnostic pop
 	      __unwind_single_frame ((PCONTEXT) &context.uc_mcontext);
 	      if (stackptr > stack)
 		{


### PR DESCRIPTION
This is a backport from 7e3c833592 (Cygwin: suppress a warning generated with w32api >= 12.0.0, 2024-06-07) and is a companion-in-spirit of https://github.com/msys2/msys2-runtime/pull/215.