### PR TITLE
Cygwin: pipe: Fix a regression that raw_write() slows down

### DIFF
--- a/winsup/cygwin/fhandler/pipe.cc
+++ b/winsup/cygwin/fhandler/pipe.cc
@@ -503,8 +503,9 @@ fhandler_pipe_fifo::raw_write (const void *ptr, size_t len)
 		      raise (SIGPIPE);
 		      goto out;
 		    }
-		  else
-		    cygwait (select_sem, 10, cw_cancel);
+		  /* Break out on completion */
+		  if (waitret == WAIT_OBJECT_0)
+		    break;
 		  /* If we got a timeout in the blocking case, and we already
 		     did a short write, we got a signal in the previous loop. */
 		  if (waitret == WAIT_TIMEOUT && short_write_once)
@@ -512,6 +513,7 @@ fhandler_pipe_fifo::raw_write (const void *ptr, size_t len)
 		      waitret = WAIT_SIGNALED;
 		      break;
 		    }
+		  cygwait (select_sem, 10, cw_cancel);
 		}
 	      /* Loop in case of blocking write or SA_RESTART */
 	      while (waitret == WAIT_TIMEOUT || waitret == WAIT_SIGNALED);


### PR DESCRIPTION
It was [reported to the Cygwin mailing list](https://cygwin.com/pipermail/cygwin/2024-August/256398.html) that a `grep` on a large file was much slower than it used to be. This is a backport of the fix.