### PR TITLE
fixup! cygthread: suspend thread before terminating.

### DIFF
--- a/winsup/cygwin/pinfo.cc
+++ b/winsup/cygwin/pinfo.cc
@@ -1262,13 +1262,14 @@ proc_waiter (void *arg)
 
   for (;;)
     {
-      DWORD nb;
+      DWORD nb, err;
       char buf = '\0';
 
       if (!ReadFile (vchild.rd_proc_pipe, &buf, 1, &nb, NULL)
-	  && GetLastError () != ERROR_BROKEN_PIPE)
+	  && (err = GetLastError ()) != ERROR_BROKEN_PIPE)
 	{
-	  system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
+	  if (err != ERROR_OPERATION_ABORTED)
+	    system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
 	  break;
 	}
 


### PR DESCRIPTION
Suppress error output if ReadFile on child wait pipe returns ERROR_OPERATION_ABORTED due to addition of CancelSynchronousIo call.

@lazka can you test this, since you saw the error?