### PR TITLE
backport fixup! cygthread: suspend thread before terminating. to 3.3.6

### DIFF
--- a/winsup/cygwin/pinfo.cc
+++ b/winsup/cygwin/pinfo.cc
@@ -1210,13 +1210,14 @@ proc_waiter (void *arg)
 
   for (;;)
     {
-      DWORD nb;
+      DWORD nb, err;
       char buf = '\0';
 
       if (!ReadFile (vchild.rd_proc_pipe, &buf, 1, &nb, NULL)
-	  && GetLastError () != ERROR_BROKEN_PIPE)
+	  && (err = GetLastError ()) != ERROR_BROKEN_PIPE)
 	{
-	  system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
+	  if (err != ERROR_OPERATION_ABORTED)
+	    system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
 	  break;
 	}
 


### PR DESCRIPTION
Suppress error output if ReadFile on child wait pipe returns ERROR_OPERATION_ABORTED due to addition of CancelSynchronousIo call.

backport of #236