### PR TITLE
fixup cygthread: suspend thread before terminating to version merged upstream.

### DIFF
--- a/winsup/cygwin/pinfo.cc
+++ b/winsup/cygwin/pinfo.cc
@@ -1268,6 +1268,9 @@ proc_waiter (void *arg)
       if (!ReadFile (vchild.rd_proc_pipe, &buf, 1, &nb, NULL)
 	  && (err = GetLastError ()) != ERROR_BROKEN_PIPE)
 	{
+	  /* ERROR_OPERATION_ABORTED is expected due to the possibility that
+	     CancelSynchronousIo interruped the ReadFile call, so don't output
+	     that error */
 	  if (err != ERROR_OPERATION_ABORTED)
 	    system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
 	  break;

--- a/winsup/cygwin/sigproc.cc
+++ b/winsup/cygwin/sigproc.cc
@@ -409,9 +409,12 @@ proc_terminate ()
 	     to 1 iff it is a Cygwin process.  */
 	  if (!have_execed || !have_execed_cygwin)
 	    chld_procs[i]->ppid = 1;
-	  if (chld_procs[i].wait_thread)
-	    if (!CancelSynchronousIo (chld_procs[i].wait_thread->thread_handle ()))
-	      chld_procs[i].wait_thread->terminate_thread ();
+	  /* Attempt to exit the wait_thread cleanly via CancelSynchronousIo
+	     before falling back to the (explicitly dangerous) cross-thread
+	     termination */
+	  if (chld_procs[i].wait_thread
+	      && !CancelSynchronousIo (chld_procs[i].wait_thread->thread_handle ()))
+	    chld_procs[i].wait_thread->terminate_thread ();
 	  /* Release memory associated with this process unless it is 'myself'.
 	     'myself' is only in the chld_procs table when we've execed.  We
 	     reach here when the next process has finished initializing but we
@@ -1175,7 +1178,11 @@ remove_proc (int ci)
 {
   if (have_execed)
     {
-      if (_my_tls._ctinfo != chld_procs[ci].wait_thread)
+      /* Attempt to exit the wait_thread cleanly via CancelSynchronousIo
+	 before falling back to the (explicitly dangerous) cross-thread
+	 termination */
+      if (_my_tls._ctinfo != chld_procs[ci].wait_thread
+	  && !CancelSynchronousIo (chld_procs[ci].wait_thread->thread_handle ()))
 	chld_procs[ci].wait_thread->terminate_thread ();
     }
   else if (chld_procs[ci] && chld_procs[ci]->exists ())


### PR DESCRIPTION
Address review comments:
* add comments
* change nested ifs to && conditions

Added CancelSynchronousIo before another terminate_thread call, which was not the one that was causing issues, but still makes sense to avoid termination if possible.

This brings the whole thing (after `autosquash`) to match what was merged upstream (b091b47b9e569389ad68bf28274c88d22be38ca5).

Should I add some sort of "backported from" trailer to the commit message too (using `--fixup=reword:`?)  Or is there some other git trick I should use to make sure this works out clearly when rebased in future versions?