### PR TITLE
fixup! CI: add a GHA for doing a basic build test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-msys2
         uses: msys2/setup-msys2@v2
@@ -33,7 +33,7 @@ jobs:
           make DESTDIR="$(pwd)"/_dest install
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: install
           path: _dest/


### PR DESCRIPTION
Update actions to node20 versions to avoid deprecation warnings.

Just tired of looking at them 😉 