### PR TITLE
Cygwin: uname: add host machine tag to sysname

### DIFF
--- a/winsup/cygwin/local_includes/wincap.h
+++ b/winsup/cygwin/local_includes/wincap.h
@@ -42,6 +42,8 @@ class wincapc
   RTL_OSVERSIONINFOEXW	version;
   char			osnam[40];
   const void		*caps;
+  USHORT		host_mach;
+  USHORT		cygwin_mach;
   bool			_is_server;
 
 public:
@@ -61,6 +63,8 @@ public:
 		     { return (size_t) system_info.dwAllocationGranularity; }
   const char *osname () const { return osnam; }
   const DWORD build_number () const { return version.dwBuildNumber; }
+  const USHORT host_machine () const { return host_mach; }
+  const USHORT cygwin_machine () const { return cygwin_mach; }
 
 #define IMPLEMENT(cap) cap() const { return ((wincaps *) this->caps)->cap; }
 

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -4826,14 +4826,12 @@ find_fast_cwd_pointer ()
 static fcwd_access_t **
 find_fast_cwd ()
 {
-  USHORT emulated, hosted;
   fcwd_access_t **f_cwd_ptr;
 
-  /* First check if we're running in WOW64 on ARM64 emulating AMD64.  Skip
+  /* First check if we're running on an ARM64 system.  Skip
      fetching FAST_CWD pointer as long as there's no solution for finding
      it on that system. */
-  if (IsWow64Process2 (GetCurrentProcess (), &emulated, &hosted)
-      && hosted == IMAGE_FILE_MACHINE_ARM64)
+  if (wincap.host_machine () == IMAGE_FILE_MACHINE_ARM64)
     return NULL;
 
   /* Fetch the pointer but don't set the global fast_cwd_ptr yet.  First

--- a/winsup/cygwin/uname.cc
+++ b/winsup/cygwin/uname.cc
@@ -51,13 +51,27 @@ uname_x (struct utsname *name)
   __try
     {
       char buf[NI_MAXHOST + 1] ATTRIBUTE_NONSTRING;
+      int n;
 
       memset (name, 0, sizeof (*name));
       /* sysname */
       const char* sysname = get_sysname();
-      __small_sprintf (name->sysname, "%s_%s-%u",
-		       sysname,
-		       wincap.osname (), wincap.build_number ());
+      n = __small_sprintf (name->sysname, "%s_%s-%u",
+			   sysname,
+			   wincap.osname (), wincap.build_number ());
+      if (wincap.host_machine () != wincap.cygwin_machine ())
+	{
+	  switch (wincap.host_machine ())
+	    {
+	      case IMAGE_FILE_MACHINE_ARM64:
+		n = stpcpy (name->sysname + n, "-ARM64") - name->sysname;
+		break;
+	      default:
+		n += __small_sprintf (name->sysname + n, "-%04y",
+				      (int) wincap.host_machine ());
+		break;
+	    }
+	}
       /* nodename */
       memset (buf, 0, sizeof buf);
       cygwin_gethostname (buf, sizeof buf - 1);


### PR DESCRIPTION
This backports two commits from cygwin master, caching IsWow64Process2 and the cygwin module's architecture in wincap, and using this to add a host machine tag to uname's sysname field, like used to be done with `-WOW64` when that was supported (see forthcoming PR to 3.3.6 for more complete version that includes handling of i686 cases, which were removed during review before applying to cygwin, since they no longer support i686)

Closes #238