### PR TITLE
Cygwin: uname: add host machine tag to sysname

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -5023,14 +5023,12 @@ find_fast_cwd_pointer ()
 static fcwd_access_t **
 find_fast_cwd ()
 {
-  USHORT emulated, hosted;
   fcwd_access_t **f_cwd_ptr;
 
-  /* First check if we're running in WOW64 on ARM64 emulating AMD64.  Skip
+  /* First check if we're running on an ARM64 system.  Skip
      fetching FAST_CWD pointer as long as there's no solution for finding
      it on that system. */
-  if (IsWow64Process2 (GetCurrentProcess (), &emulated, &hosted)
-      && hosted == IMAGE_FILE_MACHINE_ARM64)
+  if (wincap.host_machine () == IMAGE_FILE_MACHINE_ARM64)
     f_cwd_ptr = NULL;
   else
     {

--- a/winsup/cygwin/uname.cc
+++ b/winsup/cygwin/uname.cc
@@ -51,14 +51,34 @@ uname_x (struct utsname *name)
     {
       char buf[NI_MAXHOST + 1] ATTRIBUTE_NONSTRING;
       char *snp = strstr (cygwin_version.dll_build_date, "SNP");
+      int n;
 
       memset (name, 0, sizeof (*name));
       /* sysname */
       const char* sysname = get_sysname();
-      __small_sprintf (name->sysname, "%s_%s-%u%s",
-		       sysname,
-		       wincap.osname (), wincap.build_number (),
-		       wincap.is_wow64 () ? "-WOW64" : "");
+      n = __small_sprintf (name->sysname, "%s_%s-%u",
+			   sysname,
+			   wincap.osname (), wincap.build_number ());
+      if (wincap.host_machine () != wincap.cygwin_machine ())
+	{
+	  switch (wincap.host_machine ())
+	    {
+	      case IMAGE_FILE_MACHINE_AMD64:
+		/* special case for backwards compatibility */
+		if (wincap.cygwin_machine () == IMAGE_FILE_MACHINE_I386)
+		  n = stpcpy (name->sysname + n, "-WOW64") - name->sysname;
+		else
+		  n = stpcpy (name->sysname + n, "-x64") - name->sysname;
+		break;
+	      case IMAGE_FILE_MACHINE_ARM64:
+		n = stpcpy (name->sysname + n, "-ARM64") - name->sysname;
+		break;
+	      default:
+		n += __small_sprintf (name->sysname + n, "-%04y",
+				      (int) wincap.host_machine ());
+		break;
+	    }
+	}
       /* nodename */
       memset (buf, 0, sizeof buf);
       cygwin_gethostname (buf, sizeof buf - 1);

--- a/winsup/cygwin/wincap.h
+++ b/winsup/cygwin/wincap.h
@@ -57,6 +57,8 @@ class wincapc
   char			osnam[40];
   ULONG_PTR		wow64;
   void			*caps;
+  USHORT		host_mach;
+  USHORT		cygwin_mach;
 
 public:
   void init ();
@@ -76,6 +78,8 @@ public:
   const char *osname () const { return osnam; }
   const DWORD build_number () const { return version.dwBuildNumber; }
   const bool is_wow64 () const { return !!wow64; }
+  const USHORT host_machine () const { return host_mach; }
+  const USHORT cygwin_machine () const { return cygwin_mach; }
 
 #define IMPLEMENT(cap) cap() const { return ((wincaps *) this->caps)->cap; }
 


### PR DESCRIPTION
This backports two commits from cygwin master, caching IsWow64Process2 and the cygwin module's architecture in wincap, and using this to add a host machine tag to uname's sysname field, like -WOW64 for the i686-on-x86_64 case.  This is a more complete version of #244 with i686 cases handled also, including i686-on-x86_64 case for Windows versions before IsWow64Process2 existed (which is commonly known as WOW64).

I tested this version of the code most extensively, on (matrix values are `uname -s` output, column headers are `uname -m` output):
```
				Cygwin
Host		i686				x86_64
vista/i686	MSYS_NT-6.0-6002		(N/A)
vista/x86_64	MSYS_NT-6.0-6002-WOW64		MSYS_NT-6.0-6002
10/i686		MSYS_NT-10.0-19045		(N/A)
10/x86_64	MSYS_NT-10.0-19045-WOW64	MSYS_NT-10.0-19045
10/ARM64	MSYS_NT-10.0-19045-ARM64	(N/A)
11/x86_64	MSYS_NT-10.0-22631-WOW64	MSYS_NT-10.0-22631
11/ARM64	MSYS_NT-10.0-22631-ARM64	MSYS_NT-10.0-22631-ARM64
```