### PR TITLE
Some `msys2-runtime-commit` fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
           # resulting in errors due to -Werror. Disable them for now.
           export CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=array-bounds -Wno-error=overloaded-virtual -Wno-narrowing -Wno-use-after-free -Wno-error=maybe-uninitialized"
           (cd winsup && ./autogen.sh)
-          ./configure --disable-dependency-tracking
+          ./configure --disable-dependency-tracking --with-msys2-runtime-commit=$GITHUB_SHA
           make -j8
 
       - name: Install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
           # resulting in errors due to -Werror. Disable them for now.
           export CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=array-bounds -Wno-error=overloaded-virtual -Wno-narrowing -Wno-use-after-free -Wno-error=maybe-uninitialized"
           (cd winsup && ./autogen.sh)
-          ./configure --disable-dependency-tracking --with-msys2-runtime-commit=$GITHUB_SHA
+          ./configure --disable-dependency-tracking --with-msys2-runtime-commit="$GITHUB_SHA"
           make -j8
 
       - name: Install

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -74,7 +74,7 @@ yes|auto)
         MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
         MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
     else
-        AC_MSG_WARN([Could not determine msys2-runtime commit"])
+        AC_MSG_WARN([Could not determine msys2-runtime commit])
         MSYS2_RUNTIME_COMMIT=
         MSYS2_RUNTIME_COMMIT_SHORT=
         MSYS2_RUNTIME_COMMIT_HEX=0


### PR DESCRIPTION
I noticed recently that the `msys-2.0.dll` files built in PR builds lacked the commit information, which makes it easier to get confused when bisecting issues such as the v3.5.5 hangs.

This PR does not fix the hangs, but the recorded commit information (that is part of the output of `uname -a`).