### PR TITLE
deepcopy symlink improvements

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2160,6 +2160,10 @@ symlink_deepcopy (const char *oldpath, path_conv &win32_newpath)
   tmp_pathbuf tp;
   path_conv win32_oldpath;
 
+  /* **BEGIN** replace this with
+     resolve_symlink_target (oldpath, win32_newpath. win32_oldpath);
+     when rebasing over 5a706ff0fceb83fd1fe7f072fc28a741fdde65f2
+     (probably Cygwin 3.6) */
   /* The symlink target is relative to the directory in which the
      symlink gets created, not relative to the cwd.  Therefore we
      have to mangle the path quite a bit before calling path_conv.*/
@@ -2174,6 +2178,7 @@ symlink_deepcopy (const char *oldpath, path_conv &win32_newpath)
 	      oldpath);
       win32_oldpath.check (absoldpath, PC_SYM_NOFOLLOW, stat_suffixes);
     }
+  /* **END** */
   if (win32_oldpath.error)
     {
       set_errno (win32_oldpath.error);

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2073,6 +2073,79 @@ symlink_wsl (const char *oldpath, path_conv &win32_newpath)
 }
 
 int
+symlink_deepcopy (const char *oldpath, path_conv &win32_newpath)
+{
+  tmp_pathbuf tp;
+  path_conv src_path;
+
+  src_path.check (oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
+  if (src_path.error)
+    {
+      set_errno (src_path.error);
+      return -1;
+    }
+  if (src_path.isspecial ())
+    return -2;
+
+  /* MSYS copy file instead make symlink */
+  char * real_oldpath;
+  if (isabspath (oldpath))
+    strcpy (real_oldpath = tp.c_get (), oldpath);
+  else
+    /* Find the real source path, relative
+       to the directory of the destination */
+    {
+      /* Determine the character position of the last path component */
+      const char *newpath = win32_newpath.get_posix();
+      int pos = strlen (newpath);
+      while (--pos >= 0)
+	if (isdirsep (newpath[pos]))
+	  break;
+      /* Append the source path to the directory
+	 component of the destination */
+      if (pos+1+strlen(oldpath) >= MAX_PATH)
+	{
+	  set_errno(ENAMETOOLONG);
+	  return -1;
+	}
+      strcpy (real_oldpath = tp.c_get (), newpath);
+      strcpy (&real_oldpath[pos+1], oldpath);
+    }
+
+  /* As a MSYS limitation, the source path must exist. */
+  path_conv win32_oldpath;
+  win32_oldpath.check (real_oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
+  if (!win32_oldpath.exists ())
+    {
+      set_errno (ENOENT);
+      return -1;
+    }
+
+  char *w_newpath;
+  char *w_oldpath;
+  stpcpy (w_newpath = tp.c_get (), win32_newpath.get_win32());
+  stpcpy (w_oldpath = tp.c_get (), win32_oldpath.get_win32());
+  if (win32_oldpath.isdir())
+    {
+      char *origpath;
+      strcpy (origpath = tp.c_get (), w_oldpath);
+      return recursiveCopy (w_oldpath, w_newpath, origpath);
+    }
+  else
+    {
+      if (!CopyFile (w_oldpath, w_newpath, FALSE))
+	{
+	  __seterrno ();
+	  return -1;
+	}
+      else
+	{
+	  return 0;
+	}
+    }
+}
+
+int
 symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 {
   int res = -1;
@@ -2140,6 +2213,13 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	case WSYM_nfs:
 	  res = symlink_nfs (oldpath, win32_newpath);
 	  __leave;
+	case WSYM_deepcopy:
+	  res = symlink_deepcopy (oldpath, win32_newpath);
+	  if (!res || res == -1)
+	    __leave;
+	  /* fall back to sysfile symlink type */
+	  wsym_type = WSYM_sysfile;
+	  break;
 	case WSYM_native:
 	case WSYM_nativestrict:
 	  res = symlink_native (oldpath, win32_newpath);
@@ -2308,77 +2388,6 @@ symlink_worker (const char *oldpath, path_conv &win32_newpath, bool isdevice)
 	}
       else /* wsym_type == WSYM_sysfile */
 	{
-          if (wsym_type == WSYM_deepcopy)
-	    {
-	      path_conv src_path;
-	      src_path.check (oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
-	      if (src_path.error)
-		{
-		  set_errno (src_path.error);
-		  __leave;
-		}
-	      if (!src_path.isspecial ())
-	        {
-		  /* MSYS copy file instead make symlink */
-
-		  char * real_oldpath;
-		  if (isabspath (oldpath))
-		    strcpy (real_oldpath = tp.c_get (), oldpath);
-		  else
-		    /* Find the real source path, relative
-		       to the directory of the destination */
-		    {
-		      /* Determine the character position of the last path component */
-		      const char *newpath = win32_newpath.get_posix();
-		      int pos = strlen (newpath);
-		      while (--pos >= 0)
-			if (isdirsep (newpath[pos]))
-			  break;
-		      /* Append the source path to the directory
-			 component of the destination */
-		      if (pos+1+strlen(oldpath) >= MAX_PATH)
-			{
-			  set_errno(ENAMETOOLONG);
-			  __leave;
-			}
-		      strcpy (real_oldpath = tp.c_get (), newpath);
-		      strcpy (&real_oldpath[pos+1], oldpath);
-		    }
-
-		  /* As a MSYS limitation, the source path must exist. */
-		  path_conv win32_oldpath;
-		  win32_oldpath.check (real_oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
-		  if (!win32_oldpath.exists ())
-		    {
-		      set_errno (ENOENT);
-		      __leave;
-		    }
-
-		  char *w_newpath;
-		  char *w_oldpath;
-		  stpcpy (w_newpath = tp.c_get (), win32_newpath.get_win32());
-		  stpcpy (w_oldpath = tp.c_get (), win32_oldpath.get_win32());
-		  if (win32_oldpath.isdir())
-		    {
-		      char *origpath;
-		      strcpy (origpath = tp.c_get (), w_oldpath);
-		      res = recursiveCopy (w_oldpath, w_newpath, origpath);
-		    }
-		  else
-		    {
-		      if (!CopyFile (w_oldpath, w_newpath, FALSE))
-			{
-			  __seterrno ();
-			}
-		      else
-			{
-			  res = 0;
-			}
-		    }
-		  __leave;
-		}
-	    }
-
 	  /* Default technique creating a symlink. */
 	  buf = tp.t_get ();
 	  cp = stpcpy (buf, SYMLINK_COOKIE);

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1735,6 +1735,7 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
   findfiles = FindNextFileW (dH, &dHfile);
   while (findfiles)
     {
+      bool isdirlink = false;
       /* Append the directory item filename to both source and destination */
       debug_printf ("dHfile(3): %W", dHfile.cFileName);
       src->Length = srcpos + sizeof (WCHAR);
@@ -1742,25 +1743,44 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
       RtlAppendUnicodeToString (src, dHfile.cFileName);
       RtlAppendUnicodeToString (dst, dHfile.cFileName);
       debug_printf ("%S -> %S", src, dst);
-      if (dHfile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+      if ((dHfile.dwFileAttributes &
+	    (FILE_ATTRIBUTE_DIRECTORY|FILE_ATTRIBUTE_REPARSE_POINT)) ==
+	  (FILE_ATTRIBUTE_DIRECTORY|FILE_ATTRIBUTE_REPARSE_POINT))
+	{
+	  /* this sucks hard */
+	  path_conv pc (src, PC_SYM_NOFOLLOW|PC_SYM_NOFOLLOW_REP);
+	  isdirlink = pc.issymlink ();
+	}
+      if (isdirlink)
         {
-          /* Recurse into the child directory */
-          debug_printf ("%S <-> %W", src, origpath);
+	  /* CreateDirectoryEx seems to "copy" directory reparse points, which
+	     CopyFileEx can only do with a flag introduced in 19041. */
+	  if (!CreateDirectoryExW (src->Buffer, dst->Buffer, NULL))
+	    {
+	      debug_printf ("CreateDirectoryExW(%S, %S, 0) failed", src, dst);
+	      __seterrno ();
+	      goto done;
+	    }
+	}
+      else if (dHfile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+	{
+	  /* Recurse into the child directory */
+	  debug_printf ("%S <-> %W", src, origpath);
 	  // avoids endless recursion
-          if (wcsncmp (src->Buffer, origpath, src->Length / sizeof (WCHAR)))
-            if (recursiveCopy (src, dst, origpath))
-              goto done;
-        }
+	  if (wcsncmp (src->Buffer, origpath, src->Length / sizeof (WCHAR)))
+	    if (recursiveCopy (src, dst, origpath))
+	      goto done;
+	}
       else
-        {
-          /* Just copy the file */
-          if (!CopyFileExW (src->Buffer, dst->Buffer, NULL, NULL, NULL,
+	{
+	  /* Just copy the file */
+	  if (!CopyFileExW (src->Buffer, dst->Buffer, NULL, NULL, NULL,
 			    COPY_FILE_COPY_SYMLINK))
-            {
-              __seterrno ();
-              goto done;
-            }
-        }
+	    {
+	      __seterrno ();
+	      goto done;
+	    }
+	}
       findfiles = FindNextFileW (dH, &dHfile);
     }
   if (GetLastError() != ERROR_NO_MORE_FILES)
@@ -2132,17 +2152,41 @@ symlink_deepcopy (const char *oldpath, path_conv &win32_newpath)
     }
   else
     {
-      if (!CopyFileExW (w_oldpath->Buffer, w_newpath->Buffer,
-			NULL, NULL, NULL, COPY_FILE_COPY_SYMLINK))
+      bool isdirlink = false;
+      if (win32_oldpath.issymlink () &&
+	  win32_oldpath.is_known_reparse_point ())
+	{
+	  /* Is there a better way to know this? */
+	  DWORD attr = getfileattr (win32_oldpath.get_win32 (),
+				    !!win32_oldpath.objcaseinsensitive ());
+	  if (attr == INVALID_FILE_ATTRIBUTES)
+	    {
+	      __seterrno ();
+	      return -1;
+	    }
+	  isdirlink = attr & FILE_ATTRIBUTE_DIRECTORY;
+	}
+      if (isdirlink)
+        {
+	  /* CreateDirectoryEx seems to "copy" directory reparse points, which
+	     CopyFileEx can only do with a flag introduced in 19041. */
+	  if (!CreateDirectoryExW (w_oldpath->Buffer, w_newpath->Buffer, NULL))
+	    {
+	      debug_printf ("CreateDirectoryExW(%S, %S, 0) failed", w_oldpath,
+			    w_newpath);
+	      __seterrno ();
+	      return -1;
+	    }
+	}
+      else if (!CopyFileExW (w_oldpath->Buffer, w_newpath->Buffer, NULL, NULL,
+			NULL, COPY_FILE_COPY_SYMLINK))
 	{
 	  __seterrno ();
 	  return -1;
 	}
-      else
-	{
-	  return 0;
-	}
     }
+
+  return 0;
 }
 
 int

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1693,69 +1693,75 @@ conv_path_list (const char *src, char *dst, size_t size,
   Create a deep copy of src as dst, while avoiding descending in origpath.
 */
 static int
-recursiveCopy (char * src, char * dst, const char * origpath)
+recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
 {
-  WIN32_FIND_DATA dHfile;
+  WIN32_FIND_DATAW dHfile;
   HANDLE dH = INVALID_HANDLE_VALUE;
   BOOL findfiles;
-  int srcpos = strlen (src);
-  int dstpos = strlen (dst);
+  int srcpos = src->Length;
+  int dstpos = dst->Length;
   int res = -1;
 
-  debug_printf("recursiveCopy (%s, %s)", src, dst);
+  debug_printf ("recursiveCopy (%S, %S)", src, dst);
 
   /* Create the destination directory */
-  if (!CreateDirectoryEx (src, dst, NULL))
+  if (!CreateDirectoryExW (src->Buffer, dst->Buffer, NULL))
     {
-      debug_printf("CreateDirectoryEx(%s, %s, 0) failed", src, dst);
+      debug_printf ("CreateDirectoryExW(%S, %S, 0) failed", src, dst);
       __seterrno ();
       goto done;
     }
   /* Descend into the source directory */
-  if (srcpos + 2 >= MAX_PATH || dstpos + 1 >= MAX_PATH)
+  if (src->Buffer[(src->Length - 1) / sizeof (WCHAR)] != L'\\')
     {
-      set_errno (ENAMETOOLONG);
-      goto done;
+      RtlAppendUnicodeToString (src, L"\\*");
     }
-  strcat (src, "\\*");
-  strcat (dst, "\\");
-  dH = FindFirstFile (src, &dHfile);
-  debug_printf("dHfile(1): %s", dHfile.cFileName);
-  findfiles = FindNextFile (dH, &dHfile);
-  debug_printf("dHfile(2): %s", dHfile.cFileName);
-  findfiles = FindNextFile (dH, &dHfile);
+  else
+    {
+      RtlAppendUnicodeToString (src, L"*");
+      srcpos -= sizeof (WCHAR);
+    }
+  if (dst->Buffer[(dst->Length - 1) / sizeof (WCHAR)] != L'\\')
+      RtlAppendUnicodeToString (dst, L"\\");
+  else
+      dstpos -= sizeof (WCHAR);
+
+  dH = FindFirstFileExW (src->Buffer, FindExInfoBasic, &dHfile,
+			 FindExSearchNameMatch, NULL,
+			 FIND_FIRST_EX_LARGE_FETCH);
+  debug_printf ("dHfile(1): %W", dHfile.cFileName);
+  findfiles = FindNextFileW (dH, &dHfile);
+  debug_printf ("dHfile(2): %W", dHfile.cFileName);
+  findfiles = FindNextFileW (dH, &dHfile);
   while (findfiles)
     {
       /* Append the directory item filename to both source and destination */
-      int filelen = strlen (dHfile.cFileName);
-      debug_printf("dHfile(3): %s", dHfile.cFileName);
-      if (srcpos + 1 + filelen >= MAX_PATH ||
-          dstpos + 1 + filelen >= MAX_PATH)
-        {
-          set_errno (ENAMETOOLONG);
-          goto done;
-        }
-      strcpy (&src[srcpos+1], dHfile.cFileName);
-      strcpy (&dst[dstpos+1], dHfile.cFileName);
-      debug_printf("%s -> %s", src, dst);
+      debug_printf ("dHfile(3): %W", dHfile.cFileName);
+      src->Length = srcpos + sizeof (WCHAR);
+      dst->Length = dstpos + sizeof (WCHAR);
+      RtlAppendUnicodeToString (src, dHfile.cFileName);
+      RtlAppendUnicodeToString (dst, dHfile.cFileName);
+      debug_printf ("%S -> %S", src, dst);
       if (dHfile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
           /* Recurse into the child directory */
-          debug_printf("%s <-> %s", src, origpath);
-          if (strcmp (src, origpath)) // avoids endless recursion
+          debug_printf ("%S <-> %W", src, origpath);
+	  // avoids endless recursion
+          if (wcsncmp (src->Buffer, origpath, src->Length / sizeof (WCHAR)))
             if (recursiveCopy (src, dst, origpath))
               goto done;
         }
       else
         {
           /* Just copy the file */
-          if (!CopyFile (src, dst, FALSE))
+          if (!CopyFileExW (src->Buffer, dst->Buffer, NULL, NULL, NULL,
+			    COPY_FILE_COPY_SYMLINK))
             {
               __seterrno ();
               goto done;
             }
         }
-      findfiles = FindNextFile (dH, &dHfile);
+      findfiles = FindNextFileW (dH, &dHfile);
     }
   if (GetLastError() != ERROR_NO_MORE_FILES)
     {
@@ -2076,64 +2082,58 @@ int
 symlink_deepcopy (const char *oldpath, path_conv &win32_newpath)
 {
   tmp_pathbuf tp;
-  path_conv src_path;
+  path_conv win32_oldpath;
 
-  src_path.check (oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
-  if (src_path.error)
+  /* The symlink target is relative to the directory in which the
+     symlink gets created, not relative to the cwd.  Therefore we
+     have to mangle the path quite a bit before calling path_conv.*/
+  if (isabspath (oldpath))
+    win32_oldpath.check (oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
+  else
     {
-      set_errno (src_path.error);
+      size_t len = strrchr (win32_newpath.get_posix (), '/')
+		    - win32_newpath.get_posix () + 1;
+      char *absoldpath = tp.t_get ();
+      stpcpy (stpncpy (absoldpath, win32_newpath.get_posix (), len),
+	      oldpath);
+      win32_oldpath.check (absoldpath, PC_SYM_NOFOLLOW, stat_suffixes);
+    }
+  if (win32_oldpath.error)
+    {
+      set_errno (win32_oldpath.error);
       return -1;
     }
-  if (src_path.isspecial ())
+  if (win32_oldpath.isspecial ())
     return -2;
 
   /* MSYS copy file instead make symlink */
-  char * real_oldpath;
-  if (isabspath (oldpath))
-    strcpy (real_oldpath = tp.c_get (), oldpath);
-  else
-    /* Find the real source path, relative
-       to the directory of the destination */
-    {
-      /* Determine the character position of the last path component */
-      const char *newpath = win32_newpath.get_posix();
-      int pos = strlen (newpath);
-      while (--pos >= 0)
-	if (isdirsep (newpath[pos]))
-	  break;
-      /* Append the source path to the directory
-	 component of the destination */
-      if (pos+1+strlen(oldpath) >= MAX_PATH)
-	{
-	  set_errno(ENAMETOOLONG);
-	  return -1;
-	}
-      strcpy (real_oldpath = tp.c_get (), newpath);
-      strcpy (&real_oldpath[pos+1], oldpath);
-    }
-
   /* As a MSYS limitation, the source path must exist. */
-  path_conv win32_oldpath;
-  win32_oldpath.check (real_oldpath, PC_SYM_NOFOLLOW, stat_suffixes);
   if (!win32_oldpath.exists ())
     {
       set_errno (ENOENT);
       return -1;
     }
 
-  char *w_newpath;
-  char *w_oldpath;
-  stpcpy (w_newpath = tp.c_get (), win32_newpath.get_win32());
-  stpcpy (w_oldpath = tp.c_get (), win32_oldpath.get_win32());
-  if (win32_oldpath.isdir())
+  PUNICODE_STRING w_oldpath = win32_oldpath.get_nt_native_path ();
+  PUNICODE_STRING w_newpath = win32_newpath.get_nt_native_path ();
+  if (w_oldpath->Buffer[1] == L'?')
+    w_oldpath->Buffer[1] = L'\\';
+  if (w_newpath->Buffer[1] == L'?')
+    w_newpath->Buffer[1] = L'\\';
+  if (win32_oldpath.isdir ())
     {
-      char *origpath;
-      strcpy (origpath = tp.c_get (), w_oldpath);
-      return recursiveCopy (w_oldpath, w_newpath, origpath);
+      PWCHAR origpath = win32_oldpath.get_wide_win32_path (tp.w_get ());
+      /* we need a larger UNICODE_STRING MaximumLength than
+	 get_nt_native_path allocates for the recursive copy */
+      UNICODE_STRING u_oldpath, u_newpath;
+      RtlCopyUnicodeString (tp.u_get (&u_oldpath), w_oldpath);
+      RtlCopyUnicodeString (tp.u_get (&u_newpath), w_newpath);
+      return recursiveCopy (&u_oldpath, &u_newpath, origpath);
     }
   else
     {
-      if (!CopyFile (w_oldpath, w_newpath, FALSE))
+      if (!CopyFileExW (w_oldpath->Buffer, w_newpath->Buffer,
+			NULL, NULL, NULL, COPY_FILE_COPY_SYMLINK))
 	{
 	  __seterrno ();
 	  return -1;

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1706,7 +1706,8 @@ recursiveCopyCheckSymlink(PUNICODE_STRING src, bool& isdirlink)
   Create a deep copy of src as dst, while avoiding descending in origpath.
 */
 static int
-recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath, PWIN32_FIND_DATAW dHfile = NULL)
+recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, USHORT origsrclen,
+	       USHORT origdstlen, PWIN32_FIND_DATAW dHfile = NULL)
 {
   HANDLE dH = INVALID_HANDLE_VALUE;
   NTSTATUS status;
@@ -1812,11 +1813,15 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath, PWIN32
       else if (dHfile->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 	{
 	  /* Recurse into the child directory */
-	  debug_printf ("%S <-> %W", src, origpath);
-	  // avoids endless recursion
-	  if (wcsncmp (src->Buffer, origpath, src->Length / sizeof (WCHAR)))
-	    if (recursiveCopy (src, dst, origpath, dHfile))
+	  /* avoids endless recursion */
+	  if (src->Length <= origsrclen ||
+	      !wcsncmp (src->Buffer, dst->Buffer, origdstlen / sizeof (WCHAR)))
+	    {
+	      set_errno (ELOOP);
 	      goto done;
+	    }
+	  if (recursiveCopy (src, dst, origsrclen, origdstlen, dHfile))
+	    goto done;
 	}
       else
 	{
@@ -2193,13 +2198,13 @@ symlink_deepcopy (const char *oldpath, path_conv &win32_newpath)
     w_newpath->Buffer[1] = L'\\';
   if (win32_oldpath.isdir ())
     {
-      PWCHAR origpath = win32_oldpath.get_wide_win32_path (tp.w_get ());
       /* we need a larger UNICODE_STRING MaximumLength than
 	 get_nt_native_path allocates for the recursive copy */
       UNICODE_STRING u_oldpath, u_newpath;
       RtlCopyUnicodeString (tp.u_get (&u_oldpath), w_oldpath);
       RtlCopyUnicodeString (tp.u_get (&u_newpath), w_newpath);
-      return recursiveCopy (&u_oldpath, &u_newpath, origpath);
+      return recursiveCopy (&u_oldpath, &u_newpath,
+			    u_oldpath.Length, u_newpath.Length);
     }
   else
     {

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1697,6 +1697,7 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
 {
   WIN32_FIND_DATAW dHfile;
   HANDLE dH = INVALID_HANDLE_VALUE;
+  NTSTATUS status;
   int srcpos = src->Length;
   int dstpos = dst->Length;
   int res = -1;
@@ -1713,21 +1714,37 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
   /* Descend into the source directory */
   if (src->Buffer[(src->Length - 1) / sizeof (WCHAR)] != L'\\')
     {
-      RtlAppendUnicodeToString (src, L"\\*");
+      status = RtlAppendUnicodeToString (src, L"\\*");
     }
   else
     {
-      RtlAppendUnicodeToString (src, L"*");
+      status = RtlAppendUnicodeToString (src, L"*");
       srcpos -= sizeof (WCHAR);
     }
+  if (!NT_SUCCESS (status))
+    {
+      __seterrno_from_nt_status (status);
+      goto done;
+    }
   if (dst->Buffer[(dst->Length - 1) / sizeof (WCHAR)] != L'\\')
-      RtlAppendUnicodeToString (dst, L"\\");
+      status = RtlAppendUnicodeToString (dst, L"\\");
   else
       dstpos -= sizeof (WCHAR);
+  if (!NT_SUCCESS (status))
+    {
+      __seterrno_from_nt_status (status);
+      goto done;
+    }
 
   dH = FindFirstFileExW (src->Buffer, FindExInfoBasic, &dHfile,
 			 FindExSearchNameMatch, NULL,
 			 FIND_FIRST_EX_LARGE_FETCH);
+  if (dH == INVALID_HANDLE_VALUE)
+    {
+      __seterrno ();
+      goto done;
+    }
+
   do
     {
       bool isdirlink = false;
@@ -1739,8 +1756,18 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
       /* Append the directory item filename to both source and destination */
       src->Length = srcpos + sizeof (WCHAR);
       dst->Length = dstpos + sizeof (WCHAR);
-      RtlAppendUnicodeToString (src, dHfile.cFileName);
-      RtlAppendUnicodeToString (dst, dHfile.cFileName);
+      status = RtlAppendUnicodeToString (src, dHfile.cFileName);
+      if (!NT_SUCCESS (status))
+	{
+	  __seterrno_from_nt_status (status);
+	  goto done;
+	}
+      status = RtlAppendUnicodeToString (dst, dHfile.cFileName);
+      if (!NT_SUCCESS (status))
+	{
+	  __seterrno_from_nt_status (status);
+	  goto done;
+	}
       debug_printf ("%S -> %S", src, dst);
       if ((dHfile.dwFileAttributes &
 	    (FILE_ATTRIBUTE_DIRECTORY|FILE_ATTRIBUTE_REPARSE_POINT)) ==
@@ -1748,6 +1775,11 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
 	{
 	  /* this sucks hard */
 	  path_conv pc (src, PC_SYM_NOFOLLOW|PC_SYM_NOFOLLOW_REP);
+	  if (pc.error)
+	    {
+	      set_errno (pc.error);
+	      goto done;
+	    }
 	  isdirlink = pc.issymlink ();
 	}
       if (isdirlink)

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1689,18 +1689,37 @@ conv_path_list (const char *src, char *dst, size_t size,
 
 /********************** Symbolic Link Support **************************/
 
+static int
+recursiveCopyCheckSymlink(PUNICODE_STRING src, bool& isdirlink)
+{
+  path_conv pc (src, PC_SYM_NOFOLLOW|PC_SYM_NOFOLLOW_REP);
+  if (pc.error)
+    {
+      set_errno (pc.error);
+      return -1;
+    }
+  isdirlink = pc.issymlink ();
+  return 0;
+}
+
 /*
   Create a deep copy of src as dst, while avoiding descending in origpath.
 */
 static int
-recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
+recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath, PWIN32_FIND_DATAW dHfile = NULL)
 {
-  WIN32_FIND_DATAW dHfile;
   HANDLE dH = INVALID_HANDLE_VALUE;
   NTSTATUS status;
   int srcpos = src->Length;
   int dstpos = dst->Length;
   int res = -1;
+  bool freedHfile = false;
+
+  if (!dHfile)
+    {
+      dHfile = (PWIN32_FIND_DATAW) cmalloc_abort (HEAP_STR, sizeof (*dHfile));
+      freedHfile = true;
+    }
 
   debug_printf ("recursiveCopy (%S, %S)", src, dst);
 
@@ -1736,7 +1755,7 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
       goto done;
     }
 
-  dH = FindFirstFileExW (src->Buffer, FindExInfoBasic, &dHfile,
+  dH = FindFirstFileExW (src->Buffer, FindExInfoBasic, dHfile,
 			 FindExSearchNameMatch, NULL,
 			 FIND_FIRST_EX_LARGE_FETCH);
   if (dH == INVALID_HANDLE_VALUE)
@@ -1748,39 +1767,36 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
   do
     {
       bool isdirlink = false;
-      debug_printf ("dHfile: %W", dHfile.cFileName);
-      if (dHfile.cFileName[0] == L'.' &&
-	  (!dHfile.cFileName[1] ||
-	   (dHfile.cFileName[1] == L'.' && !dHfile.cFileName[2])))
+      debug_printf ("dHfile: %W", dHfile->cFileName);
+      if (dHfile->cFileName[0] == L'.' &&
+	  (!dHfile->cFileName[1] ||
+	   (dHfile->cFileName[1] == L'.' && !dHfile->cFileName[2])))
 	continue;
       /* Append the directory item filename to both source and destination */
       src->Length = srcpos + sizeof (WCHAR);
       dst->Length = dstpos + sizeof (WCHAR);
-      status = RtlAppendUnicodeToString (src, dHfile.cFileName);
+      status = RtlAppendUnicodeToString (src, dHfile->cFileName);
       if (!NT_SUCCESS (status))
 	{
 	  __seterrno_from_nt_status (status);
 	  goto done;
 	}
-      status = RtlAppendUnicodeToString (dst, dHfile.cFileName);
+      status = RtlAppendUnicodeToString (dst, dHfile->cFileName);
       if (!NT_SUCCESS (status))
 	{
 	  __seterrno_from_nt_status (status);
 	  goto done;
 	}
       debug_printf ("%S -> %S", src, dst);
-      if ((dHfile.dwFileAttributes &
+      if ((dHfile->dwFileAttributes &
 	    (FILE_ATTRIBUTE_DIRECTORY|FILE_ATTRIBUTE_REPARSE_POINT)) ==
 	  (FILE_ATTRIBUTE_DIRECTORY|FILE_ATTRIBUTE_REPARSE_POINT))
 	{
-	  /* this sucks hard */
-	  path_conv pc (src, PC_SYM_NOFOLLOW|PC_SYM_NOFOLLOW_REP);
-	  if (pc.error)
-	    {
-	      set_errno (pc.error);
-	      goto done;
-	    }
-	  isdirlink = pc.issymlink ();
+	  /* I was really hoping to avoid using path_conv in the recursion,
+	     but maybe putting it in its own function will prevent it from
+	     taking up space in the stack frame */
+	  if (recursiveCopyCheckSymlink (src, isdirlink))
+	    goto done;
 	}
       if (isdirlink)
         {
@@ -1793,13 +1809,13 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
 	      goto done;
 	    }
 	}
-      else if (dHfile.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+      else if (dHfile->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 	{
 	  /* Recurse into the child directory */
 	  debug_printf ("%S <-> %W", src, origpath);
 	  // avoids endless recursion
 	  if (wcsncmp (src->Buffer, origpath, src->Length / sizeof (WCHAR)))
-	    if (recursiveCopy (src, dst, origpath))
+	    if (recursiveCopy (src, dst, origpath, dHfile))
 	      goto done;
 	}
       else
@@ -1813,7 +1829,7 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, PCWSTR origpath)
 	    }
 	}
     }
-  while (FindNextFileW (dH, &dHfile));
+  while (FindNextFileW (dH, dHfile));
 
   if (GetLastError() != ERROR_NO_MORE_FILES)
     {
@@ -1826,6 +1842,9 @@ done:
 
   if (dH != INVALID_HANDLE_VALUE)
     FindClose (dH);
+
+  if (freedHfile)
+    cfree (dHfile);
 
   return res;
 }


### PR DESCRIPTION
Cleans up the deepcopy symlink code by:
* moving it into its own function
* making it use unicode internally, allowing for long paths and unicode characters.
* making it copy symlinks instead of their targets (wsl symlinks don't work until 19041, but everything else works all the way back to 8.1)
* adding more error checking

As part of this, I noticed this as well as a couple of other symlink handlers were doing the same thing to resolve the symlink targets.  I contributed 5a706ff0fceb83fd1fe7f072fc28a741fdde65f2 upstream, which this code can also use once it is rebased on top of that (presumably Cygwin 3.6)