### PR TITLE
Fix console mode restoring

### DIFF
--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -916,8 +916,7 @@ fhandler_console::cleanup_for_non_cygwin_app (handle_set_t *p)
   /* Cleaning-up console mode for non-cygwin app. */
   /* conmode can be tty::restore when non-cygwin app is
      exec'ed from login shell. */
-  tty::cons_mode conmode =
-    (con.owner == GetCurrentProcessId ()) ? tty::restore : tty::cygwin;
+  tty::cons_mode conmode = cons_mode_on_close (p);
   set_output_mode (conmode, ti, p);
   set_input_mode (conmode, ti, p);
   set_disable_master_thread (con.owner == GetCurrentProcessId ());
@@ -1976,22 +1975,13 @@ fhandler_console::close ()
 
   acquire_output_mutex (mutex_timeout);
 
-  if (shared_console_info[unit] && !myself->cygstarted
+  if (shared_console_info[unit] && myself->ppid == 1
       && (dev_t) myself->ctty == get_device ())
     {
-      /* Restore console mode if this is the last closure. */
-      OBJECT_BASIC_INFORMATION obi;
-      NTSTATUS status;
-      status = NtQueryObject (get_handle (), ObjectBasicInformation,
-			      &obi, sizeof obi, NULL);
-      if (NT_SUCCESS (status)
-	  && obi.HandleCount == (con.owner == GetCurrentProcessId () ? 2 : 3))
-	{
-	  /* Cleaning-up console mode for cygwin apps. */
-	  set_output_mode (tty::restore, &get_ttyp ()->ti, &handle_set);
-	  set_input_mode (tty::restore, &get_ttyp ()->ti, &handle_set);
-	  set_disable_master_thread (true, this);
-	}
+      tty::cons_mode conmode = cons_mode_on_close (&handle_set);
+      set_output_mode (conmode, &get_ttyp ()->ti, &handle_set);
+      set_input_mode (conmode, &get_ttyp ()->ti, &handle_set);
+      set_disable_master_thread (true, this);
     }
 
   if (shared_console_info[unit] && con.owner == GetCurrentProcessId ())
@@ -4689,4 +4679,29 @@ fhandler_console::fstat (struct stat *st)
       st->st_gid = p->gid;
     }
   return 0;
+}
+
+tty::cons_mode
+fhandler_console::cons_mode_on_close (handle_set_t *p)
+{
+  const _minor_t unit = p->unit;
+
+  if (myself->ppid != 1) /* Execed from normal cygwin process. */
+    return tty::cygwin;
+
+  if (!process_alive (con.owner)) /* The Master process already died. */
+    return tty::restore;
+  if (con.owner == GetCurrentProcessId ()) /* Master process */
+    return tty::restore;
+
+  PROCESS_BASIC_INFORMATION pbi;
+  NTSTATUS status =
+    NtQueryInformationProcess (GetCurrentProcess (), ProcessBasicInformation,
+			       &pbi, sizeof (pbi), NULL);
+  if (NT_SUCCESS (status)
+      && con.owner == (DWORD) pbi.InheritedFromUniqueProcessId)
+    /* The parent is the stub process. */
+    return tty::restore;
+
+  return tty::native; /* Otherwise */
 }

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -2391,6 +2391,7 @@ private:
 
   void setup_pcon_hand_over ();
   static void pcon_hand_over_proc ();
+  static tty::cons_mode cons_mode_on_close (handle_set_t *);
 
   friend tty_min * tty_list::get_cttyp ();
 };


### PR DESCRIPTION
Under certain circumstances, when a non-MSYS process is spawned from an MSYS process that is spawned from a non-MSYS process that is spawned from an MSYS process, the console state can get corrupted by the MSYS2 runtime.

This is the case, for example, [when spawning a background process that outputs to `stdout` from a Git hook](https://github.com/microsoft/git/issues/730).

This behavior is inherited from the Cygwin runtime which allows the same symptom to be reproduced as long as one is careful enough to force `git.exe` to use Cygwin's Bash to run its hooks.

The Cygwin core developer who is the only person to understand Cygwin's pseudo console handling was kind enough to fix this problem, and I backported it to the MSYS2 runtime v3.5.7.

This is a companion of https://github.com/git-for-windows/msys2-runtime/pull/87