### PR TITLE
Cygwin: console: tty::restore really restores the previous mode

### DIFF
--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -2146,6 +2146,8 @@ class dev_console
   bool disable_master_thread;
   tty::cons_mode curr_input_mode;
   tty::cons_mode curr_output_mode;
+  DWORD prev_input_mode;
+  DWORD prev_output_mode;
   bool master_thread_suspended;
   int num_processed; /* Number of input events in the current input buffer
 			already processed by cons_master_thread(). */
@@ -2366,7 +2368,7 @@ private:
 
   void setup_pcon_hand_over ();
   static void pcon_hand_over_proc ();
-  static tty::cons_mode cons_mode_on_close (handle_set_t *);
+  static tty::cons_mode cons_mode_on_close ();
 
   friend tty_min * tty_list::get_cttyp ();
 };

--- a/winsup/cygwin/release/3.6.1
+++ b/winsup/cygwin/release/3.6.1
@@ -1,0 +1,5 @@
+Fixes:
+------
+
+- Console mode is really restored to the previous mode.
+  Addresses: https://github.com/msys2/msys2-runtime/issues/268


### PR DESCRIPTION
Previously, tty::restore sets the console mode to a predetermined console mode that is widely common for many non-cygwin console apps. So, if a non-cygwin app that is started from cygwin process changes the console mode and executes cygwin sub-process, the console mode is changed to the predetermined mode rather than being restored the original mode that is set by the non-cygwin app.
With this patch, the console mode is stored when a cygwin process is started from non-cygwin app, then tty::restore restores the previous console mode that is used by the previous non-cygwin app when the cygwin app exits.

Addresses: https://github.com/msys2/msys2-runtime/issues/268
Fixes: 3312f2d21f13 ("Cygwin: console: Redesign mode set strategy on close().")
Reported-by: Eu Pin Tien, Jeremy Drake <cygwin@jdrake.com>