### PR TITLE
Cygwin: pipe: Fix hang due to inadvertent 0-length raw_write()

### DIFF
--- a/winsup/cygwin/fhandler/pipe.cc
+++ b/winsup/cygwin/fhandler/pipe.cc
@@ -1158,7 +1158,7 @@ fhandler_pipe::set_pipe_buf_size ()
   status = NtQueryInformationFile (get_handle (), &io, &fpli, sizeof fpli,
 				   FilePipeLocalInformation);
   if (NT_SUCCESS (status))
-    pipe_buf_size = fpli.InboundQuota;
+    pipe_buf_size = fpli.InboundQuota < PIPE_BUF ? PIPE_BUF : fpli.InboundQuota;
 }
 
 int


### PR DESCRIPTION
It is possible for `NtQueryInformationFile()` to report a 0-length `InboundQuota` when obtaining `FilePipeLocalInformation`. This seems to be the case e.g. when a pipe was created on the other side and its quota information is not available on the client side.

This can lead to a situation where the `avail` variable is set to 0, and since that is used to cap the number of bytes to send, a 0-length write. Which hangs forever.

This was observed in the MSYS2 project when building GIMP, and reduced to a simple test case where a MINGW `ninja.exe` tries to call an MSYS `bison.exe` and the error message (saying that `bison` wants to have some input) is not even shown.

Since the minimal pipe buffer size is 4k, let's ensure that it is at least that, even when `InboundQuota` reports 0.

This fixes https://github.com/msys2/msys2-runtime/issues/270

I am also [upstreaming this patch](https://inbox.sourceware.org/cygwin-patches/40a66dcf272eff407794bb94616d5b8ba833fafa.1743076896.git.johannes.schindelin@gmx.de/) to the Cygwin project as we speak.