### PR TITLE
fix infinite recursion check to only match subdirectories

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1855,7 +1855,9 @@ recursiveCopy (PUNICODE_STRING src, PUNICODE_STRING dst, USHORT origsrclen,
 	  /* Recurse into the child directory */
 	  /* avoids endless recursion */
 	  if (src->Length <= origsrclen ||
-	      !wcsncmp (src->Buffer, dst->Buffer, origdstlen / sizeof (WCHAR)))
+	      (!wcsncmp (src->Buffer, dst->Buffer, origdstlen / sizeof (WCHAR)) &&
+	       (!src->Buffer[origdstlen / sizeof (WCHAR)] ||
+		iswdirsep(src->Buffer[origdstlen / sizeof (WCHAR)]))))
 	    {
 	      set_errno (ELOOP);
 	      goto done;


### PR DESCRIPTION
Adjust the infinite recursion check to make sure the source ends with a dir sep, so it doesn't think abcd is a subdirectory of a.

Fixes #277