### PR TITLE
CI: run msys2-tests against freshly built runtime artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,9 @@ name: build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest
@@ -34,3 +37,59 @@ jobs:
         with:
           name: install
           path: _dest/
+
+  generate-msys2-tests-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - id: matrix
+        uses: msys2/msys2-tests/gha-matrix-gen@main
+
+  msys2-tests:
+    needs: [build, generate-msys2-tests-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.generate-msys2-tests-matrix.outputs.matrix) }}
+
+    name: msys2-tests ${{ matrix.msystem }}-${{ matrix.cc }}
+    runs-on: ${{ matrix.runner }}
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+      FC: ${{ matrix.fc }}
+    steps:
+      - id: msys2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: ${{ matrix.packages }}
+
+      - name: Add staging repo
+        shell: msys2 {0}
+        run: |
+          sed -i '1s|^|[staging]\nServer = https://repo.msys2.org/staging/\nSigLevel = Never\n|' /etc/pacman.conf
+
+      - name: Update using staging
+        shell: pwsh
+        run: |
+          msys2 -c 'pacman --noconfirm -Suuy'
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+          msys2 -c 'pacman --noconfirm -Suu'
+
+      - name: Download msys2-runtime artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: install
+          path: ${{ steps.msys2.outputs.msys2-location }}
+
+      - name: uname -a
+        shell: msys2 {0}
+        run: uname -a
+
+      - name: Run tests
+        uses: msys2/msys2-tests@main
+


### PR DESCRIPTION
Call msys2-tests composite workflows to run tests using built artifacts.

Fixes msys2/msys2-tests#24