### PR TITLE
[3.6 backport] newlib: sys/unistd.h: Change inline to __inline

### DIFF
--- a/newlib/libc/include/sys/unistd.h
+++ b/newlib/libc/include/sys/unistd.h
@@ -215,7 +215,7 @@ int     setpgrp (void);
 #if defined(__CYGWIN__) && __BSD_VISIBLE
 /* Stub for Linux libbsd compatibility. */
 #define initsetproctitle(c, a, e) setproctitle_init((c), (a), (e))
-static inline void setproctitle_init (int _c, char *_a[], char *_e[]) {}
+static __inline void setproctitle_init (int _c, char *_a[], char *_e[]) {}
 
 void setproctitle (const char *, ...)
 		   _ATTRIBUTE ((__format__ (__printf__, 1, 2)));


### PR DESCRIPTION
Addresses: https://sourceware.org/pipermail/cygwin-patches/2025q2/013644.html Fixes: 3e8a7eb1a868 ("sys/unistd.h: fix definition of setproctitle_init")
Reported-by: Brian Inglis <Brian.Inglis@SystematicSW.ab.ca>
Co-authored-by: Corinna Vinschen <corinna@vinschen.de>
Signed-off-by: Takashi Yano <takashi.yano@nifty.ne.jp>
(cherry picked from commit 1c530c37fd637ab1b7607b810d0495570932b8e7)