### PR TITLE
Re-fix console mode restoring

### DIFF
--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -905,13 +905,14 @@ fhandler_console::setup_for_non_cygwin_app ()
   /* Setting-up console mode for non-cygwin app. */
   /* If conmode is set to tty::native for non-cygwin apps
      in background, tty settings of the shell is reflected
-     to the console mode of the app. So, use tty::restore
-     for background process instead. */
-  tty::cons_mode conmode =
-    (get_ttyp ()->getpgid ()== myself->pgid) ? tty::native : tty::restore;
-  set_input_mode (conmode, &tc ()->ti, get_handle_set ());
-  set_output_mode (conmode, &tc ()->ti, get_handle_set ());
-  set_disable_master_thread (true, this);
+     to the console mode of the app. So, do not change the
+     console mode. */
+  if (get_ttyp ()->getpgid () == myself->pgid)
+    {
+      set_input_mode (tty::native, &tc ()->ti, get_handle_set ());
+      set_output_mode (tty::native, &tc ()->ti, get_handle_set ());
+      set_disable_master_thread (true, this);
+    }
 }
 
 void

--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -771,6 +771,8 @@ fhandler_console::setup ()
       con.disable_master_thread = true;
       con.master_thread_suspended = false;
       con.num_processed = 0;
+      con.curr_input_mode = tty::restore;
+      con.curr_output_mode = tty::restore;
     }
 }
 
@@ -849,11 +851,6 @@ fhandler_console::set_input_mode (tty::cons_mode m, const termios *t,
 	flags |= ENABLE_PROCESSED_INPUT;
       break;
     }
-  if (con.curr_input_mode != tty::cygwin && m == tty::cygwin)
-    {
-      prev_input_mode_backup = con.prev_input_mode;
-      con.prev_input_mode = oflags;
-    }
   con.curr_input_mode = m;
   SetConsoleMode (p->input_handle, flags);
   if (!(oflags & ENABLE_VIRTUAL_TERMINAL_INPUT)
@@ -892,11 +889,6 @@ fhandler_console::set_output_mode (tty::cons_mode m, const termios *t,
 	  && (!(t->c_oflag & OPOST) || !(t->c_oflag & ONLCR)))
 	flags |= DISABLE_NEWLINE_AUTO_RETURN;
       break;
-    }
-  if (con.curr_output_mode != tty::cygwin && m == tty::cygwin)
-    {
-      prev_output_mode_backup = con.prev_output_mode;
-      GetConsoleMode (p->output_handle, &con.prev_output_mode);
     }
   con.curr_output_mode = m;
   acquire_attach_mutex (mutex_timeout);
@@ -1836,6 +1828,12 @@ fhandler_console::open (int flags, mode_t)
   handle_set.output_handle = h;
   release_output_mutex ();
 
+  if (con.owner == GetCurrentProcessId ())
+    {
+      GetConsoleMode (get_handle (), &con.prev_input_mode);
+      GetConsoleMode (get_output_handle (), &con.prev_output_mode);
+    }
+
   wpbuf.init ();
 
   handle_set.input_mutex = input_mutex;
@@ -1879,6 +1877,19 @@ fhandler_console::open (int flags, mode_t)
       extern int sawTERM;
       if (con_is_legacy && !sawTERM)
 	setenv ("TERM", "cygwin", 1);
+    }
+
+  if (con.curr_input_mode != tty::cygwin)
+    {
+      prev_input_mode_backup = con.prev_input_mode;
+      GetConsoleMode (get_handle (), &con.prev_input_mode);
+      set_input_mode (tty::cygwin, &get_ttyp ()->ti, &handle_set);
+    }
+  if (con.curr_output_mode != tty::cygwin)
+    {
+      prev_output_mode_backup = con.prev_output_mode;
+      GetConsoleMode (get_output_handle (), &con.prev_output_mode);
+      set_output_mode (tty::cygwin, &get_ttyp ()->ti, &handle_set);
     }
 
   debug_printf ("opened conin$ %p, conout$ %p", get_handle (),
@@ -4720,7 +4731,7 @@ fhandler_console::cons_mode_on_close (handle_set_t *p)
   NTSTATUS status =
     NtQueryInformationProcess (GetCurrentProcess (), ProcessBasicInformation,
 			       &pbi, sizeof (pbi), NULL);
-  if (NT_SUCCESS (status)
+  if (NT_SUCCESS (status) && cygwin_pid (con.owner)
       && !process_alive ((DWORD) pbi.InheritedFromUniqueProcessId))
     /* Execed from normal cygwin process and the parent has been exited. */
     return tty::cygwin;


### PR DESCRIPTION
In https://github.com/msys2/msys2-runtime/pull/262, a bug was fixed that left the console in a near-blocked state under certain circumstances (e.g. when a non-MSYS2 background process was spawned in the background from an MSYS2 process and then dared to write to the console after the latter exited, or when using `git add -p` in VS Code's integrated terminal and then editing a hunk).

Sadly, this caused [a regression](https://github.com/msys2/msys2-runtime/issues/268), which was fixed in https://github.com/msys2/msys2-runtime/pull/269.

Sadly², this caused the bug that was fixed in https://github.com/msys2/msys2-runtime/pull/262 to re-appear.

I reported this to the sole Cygwin developer who understands this code and they graciously fixed it. This here PR is a backport of that fix.

This PR is a companion of https://github.com/git-for-windows/msys2-runtime/pull/95.