### PR TITLE
Do retrieve AzureAD users' information again

### DIFF
--- a/winsup/cygwin/uinfo.cc
+++ b/winsup/cygwin/uinfo.cc
@@ -1996,10 +1996,6 @@ pwdgrp::fetch_account_from_windows (fetch_user_arg_t &arg, cyg_ldap *pldap)
       if (sid_id_auth (sid) == 5 /* SECURITY_NT_AUTHORITY */
 	  && sid_sub_auth (sid, 0) == SECURITY_APPPOOL_ID_BASE_RID)
 	break;
-      /* AzureAD SIDs */
-      if (sid_id_auth (sid) == 12 /* AzureAD ID */
-	  && sid_sub_auth (sid, 0) == 1 /* Azure ID base RID */)
-	break;
       /* Samba user/group SIDs */
       if (sid_id_auth (sid) == 22)
 	break;


### PR DESCRIPTION
As of the upgrade to v3.6.2, I can no longer open any MinTTY windows:

![image](https://github.com/user-attachments/assets/7f807615-d4ce-48ae-bca9-06fbc48dc040)
This symptom (the message "Error: Could not fork child process: There are no available terminals (-1)") was also [described on the Cygwin mailing list](https://inbox.sourceware.org/cygwin/CAL148o6i=r+G=cEQzs5e+KmMt07FxJHhMnoNnquhM0JJuyrwtA@mail.gmail.com/#t).

I've bisected the problem down to 48e7d63268 (Cygwin: fetch_account_from_windows: skip LookupAccountSid for SIDs known to fail, 2025-04-10), which prevents my AzureAD user account (the SID begins with `S-1-12-1-`) from being handled correctly.

This PR is a (minimally) partial revert of that commit to resolve this problem.