### PR TITLE
Fix creating native symlinks pointing to `..`

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2030,9 +2030,18 @@ symlink_native (const char *oldpath, path_conv &win32_newpath)
       while (towupper (*++c_old) == towupper (*++c_new))
 	;
       /* The last component could share a common prefix, so make sure we end
-         up on the first char after the last common backslash. */
-      while (c_old[-1] != L'\\')
-	--c_old, --c_new;
+         up on the first char after the last common backslash.
+
+	 However, if c_old is a strict prefix of c_new (at a component
+	 boundary), or vice versa, then do not try to find the last common
+	 backslash. */
+      if ((!*c_old || *c_old == L'\\') && (!*c_new || *c_new == L'\\'))
+	c_old += !!*c_old, c_new += !!*c_new;
+      else
+	{
+	  while (c_old[-1] != L'\\')
+	    --c_old, --c_new;
+	}
 
       /* 2. Check if prefix is long enough.  The prefix must at least points to
             a complete device:  \\?\X:\ or \\?\UNC\server\share\ are the minimum
@@ -2057,8 +2066,10 @@ symlink_native (const char *oldpath, path_conv &win32_newpath)
 	  final_oldpath = &final_oldpath_buf;
 	  final_oldpath->Buffer = tp.w_get ();
 	  PWCHAR e_old = final_oldpath->Buffer;
-	  while (num-- > 0)
-	    e_old = wcpcpy (e_old, L"..\\");
+	  while (num > 1 || (num == 1 && *c_old))
+	    e_old = wcpcpy (e_old, L"..\\"), num--;
+	  if (num > 0)
+	    e_old = wcpcpy (e_old, L"..");
 	  wcpcpy (e_old, c_old);
 	}
     }


### PR DESCRIPTION
Git's test suite currently does not pass under `MSYS=winsymlinks:nativestrict`. Most of those issues need to be addressed in Git, as they are either due to incorrect assumptions, or due to bugs in the symlink support code.

However, one of the issues is in a test that first creates a symlink pointing to `..` and later verifies that following that symlink in `cat-file` works: Instead of creating a link to `..`, `ln -s` creates a link to `../../$(basename "$PWD")`. This link still points to the same entity, but it is incorrect, and not due to a bug in Git, but due to a bug in the MSYS2 runtime.

This fixes t1006.311(git cat-file --batch-check --follow-symlinks works for .. links).

I contributed this fix to the Cygwin project here: https://inbox.sourceware.org/cygwin-patches/6058889e2ae8c9c827a8d6678f09b3b1741e2fcf.1750413578.git.johannes.schindelin@gmx.de/T/#u. This PR is a companion of https://github.com/git-for-windows/msys2-runtime/pull/101.