### PR TITLE
pipe: fix SSH hang (again)

### DIFF
--- a/winsup/cygwin/fhandler/pipe.cc
+++ b/winsup/cygwin/fhandler/pipe.cc
@@ -561,7 +561,7 @@ fhandler_pipe_fifo::raw_write (const void *ptr, size_t len)
       ULONG len1;
       DWORD waitret = WAIT_OBJECT_0;
 
-      if (left > chunk && !is_nonblocking ())
+      if (left > chunk && !real_non_blocking_mode)
 	len1 = chunk;
       else
 	len1 = (ULONG) left;


### PR DESCRIPTION
The recent changes in Cygwin's pipe logic are a gift that keeps on giving.

The recurring pattern is that bugs are fixed, but with many bug fixes, new bugs are produced, and we are stuck in this seemingly endless tunnel of fixing bugs caused by bug fixes.

In cbfaeba4f7 (Cygwin: pipe: Fix incorrect write length in raw_write(), 2024-11-06), for example, a segmentation fault was fixed. Which is good! However, a bug was introduced, where e.g. Git for Windows' `git clone` via SSH frequently hangs indefinitely for large-ish repositories.

That commit removed logic whereby in non-blocking mode, not only the chunk size, but also the overall count of bytes to write (`len`) was clamped to whatever is indicated as the `WriteQuotaAvailable`. Now only `chunk` is clamped to that, but `len` is left at its original number. However, the following `while` loop expects `len - chunk` (which is assigned to `left1`) not to be positive in non-blocking mode.

Let's reinstate that clamping logic and implicitly fix this SSH hang.

This is a companion PR to https://github.com/git-for-windows/msys2-runtime/pull/102.