### PR TITLE
[3.6 backport] Cygwin: fix compatibility with GCC 15

### DIFF
--- a/winsup/cygwin/create_posix_thread.cc
+++ b/winsup/cygwin/create_posix_thread.cc
@@ -206,7 +206,7 @@ class thread_allocator
 public:
   thread_allocator () : current (THREAD_STORAGE_HIGH)
   {
-    alloc_func = wincap.has_extended_mem_api () ? &_alloc : &_alloc_old;
+    alloc_func = wincap.has_extended_mem_api () ? &thread_allocator::_alloc : &thread_allocator::_alloc_old;
   }
   PVOID alloc (SIZE_T size)
   {

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -1699,9 +1699,9 @@ class fhandler_disk_file: public fhandler_base
   uint64_t fs_ioc_getflags ();
   int fs_ioc_setflags (uint64_t);
 
-  falloc_allocate (int, off_t, off_t);
-  falloc_punch_hole (off_t, off_t);
-  falloc_zero_range (int, off_t, off_t);
+  int falloc_allocate (int, off_t, off_t);
+  int falloc_punch_hole (off_t, off_t);
+  int falloc_zero_range (int, off_t, off_t);
 
  public:
   fhandler_disk_file ();


### PR DESCRIPTION
(cherry picked from commit 83af2fd6d1018bfe1c08c0028f65076f57684474)

----

source: 5f101c3c47d7169e6fd8d2dff1ce7cdf535d5b27