### PR TITLE
POSIX-ify the GNUPGHOME variable

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -323,6 +323,7 @@ static win_env conv_envvars[] =
   {
     {NL ("PATH="), NULL, NULL, env_PATH_to_posix, env_plist_to_win32, true},
     {NL ("HOME="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
+    {NL ("GNUPGHOME="), NULL, NULL, env_path_to_posix, env_path_to_win32, false},
     {NL ("LD_LIBRARY_PATH="), NULL, NULL,
 			       env_plist_to_posix, env_plist_to_win32, true},
     {NL ("ORIGINAL_PATH="), NULL, NULL, env_PATH_to_posix, env_plist_to_win32, true},
@@ -349,7 +350,7 @@ static const unsigned char conv_start_chars[256] =
     0,        0,        0,        0,        0,        0,        0,        0,
     0,        0,        0,        0,        0,        0,        0,        0,
 /*            A         B         C         D         E         F         G */
-    0,        0,        0,        0,        0,        0,        0,        0,
+    0,        0,        0,        0,        0,        0,        0,        WC,
     /*  72 */
 /*  H         I         J         K         L         M         N         O */
     WC,       0,        0,        0,        WC,       0,        0,        WC,
@@ -361,7 +362,7 @@ static const unsigned char conv_start_chars[256] =
     0,        0,        0,        0,        0,        0,        0,        0,
     /*  96 */
 /*            a         b         c         d         e         f         g */
-    0,        0,        0,        0,        0,        0,        0,        0,
+    0,        0,        0,        0,        0,        0,        0,        WC,
     /* 104 */
 /*  h         i         j         k         l         m         n         o */
     WC,       0,        0,        0,        WC,       0,        0,        0,


### PR DESCRIPTION
When GnuPG is built for MSYS2 (e.g., as part of Git for Windows), it expects
the `GNUPGHOME` environment variable to contain a POSIX-style path
(e.g., `/c/Users/user/.gnupg`). However, users often set this variable using a
Windows-style path (e.g., `C:\Users\user\.gnupg`), which is the native format
for GnuPG for Windows.

This discrepancy leads to MSYS2-based GnuPG failing to correctly locate its home
directory when running within an environment having the `GNUPGHOME` defined in
the Windows-style, as the Windows path is not properly interpreted. This issue
prevents users from seamlessly sharing a single GnuPG home directory across
different GnuPG installations (native Windows build vs. MSYS2-based). [1] [2]

To resolve this, we posix-ify `GNUPGHOME` in a manner similar to `SHELL`. [3]
This change will allow MSYS2-based GnuPG to correctly interpret the `GNUPGHOME`
variable regardless of whether it's set with a Windows path, improving the
interoperability and user experience.

Issue [4] and [5] from git-for-windows should benefit from this change.

This addresses https://github.com/msys2/msys2-runtime/issues/297

[1]: https://lists.gnupg.org/pipermail/gnupg-users/2025-February/067533.html
[2]: https://lists.gnupg.org/pipermail/gnupg-users/2025-March/067538.html
[3]: https://github.com/msys2/msys2-runtime/commit/8bb4359ac2b3866467697e69e0142341b00e70b1
[4]: https://github.com/git-for-windows/git/discussions/5607
[5]: https://github.com/git-for-windows/git/issues/3857
