### PR TITLE
Cygwin: make create_root_entry tolerant of concurrent mount table initialization

### DIFF
--- a/winsup/cygwin/mm/shared.cc
+++ b/winsup/cygwin/mm/shared.cc
@@ -221,6 +221,7 @@ void
 user_info::create (bool reinit)
 {
   WCHAR name[UNLEN + 1] = L""; /* Large enough for SID */
+  bool created = false;
 
   if (reinit)
     {
@@ -236,11 +237,12 @@ user_info::create (bool reinit)
 
   user_shared = (user_info *) open_shared (name, USER_VERSION,
 					   cygwin_user_h, sizeof (user_info),
-					   SH_USER_SHARED, &sec_none);
-  debug_printf ("opening user shared for '%W' at %p", name, user_shared);
+					   SH_USER_SHARED, created, &sec_none);
+  debug_printf ("opening user shared for '%W' at %p, created %d",
+		name, user_shared, created);
   ProtectHandleINH (cygwin_user_h);
   debug_printf ("user shared version %x", user_shared->version);
-  if (reinit)
+  if (reinit || created)
     user_shared->initialize ();
   cygheap->shared_regions.user_shared_addr = user_shared;
 }

--- a/winsup/cygwin/mount.cc
+++ b/winsup/cygwin/mount.cc
@@ -550,7 +550,8 @@ mount_info::create_root_entry (const PWCHAR root)
   sys_wcstombs (native_root, PATH_MAX, root);
   assert (*native_root != '\0');
   if (add_item (native_root, "/",
-		MOUNT_SYSTEM | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC | MOUNT_NOACL)
+		MOUNT_SYSTEM | MOUNT_IMMUTABLE | MOUNT_AUTOMATIC | MOUNT_NOACL
+		| MOUNT_OVERRIDE)
       < 0)
     api_fatal ("add_item (\"%s\", \"/\", ...) failed, errno %d", native_root, errno);
   /* Create a default cygdrive entry.  Note that this is a user entry.


### PR DESCRIPTION
## Problem

When multiple MSYS2 processes start concurrently, `create_root_entry()`
can crash with:

    fatal error - add_item ("\??\C:\Program Files\Git", "/", ...) failed, errno 1

The `add_item()` call returns `EPERM` because it finds an existing
immutable `/` mount entry and `MOUNT_OVERRIDE` is not set.

This has been reported in several contexts where parallel MSYS2 process
startup is common:
- https://github.com/git-for-windows/git/issues/493
- https://github.com/git-for-windows/git/issues/4076
- https://github.com/git-for-windows/git/issues/3870
- https://github.com/anthropics/claude-code/issues/30165

## Changes

**mount.cc: Add `MOUNT_OVERRIDE` to `create_root_entry()`**

This is the direct fix. If `/` already exists in the mount table when
`create_root_entry()` runs, `add_item()` now overwrites it instead of
returning `EPERM`. This makes the root mount initialization idempotent.

**shared.cc: Use `created` flag from `open_shared()` in `user_info::create()`**

`open_shared()` already tracks whether the shared memory mapping was
newly created or already existed (via `CreateFileMappingW` /
`ERROR_ALREADY_EXISTS`). Currently `user_info::create()` calls the
overload that discards this flag.

This change switches to the overload that returns it, and calls
`initialize()` when `created` is true. This provides an earlier
initialization path for the process that created the shared memory,
before `dll_crt0_1()` reaches `initialize()` via the spinlock.

Note: this does not replace the existing spinlock coordination in
`initialize()`. The normal cold-start path through `dll_crt0_1()` is
unchanged. This is a supplementary improvement, not the primary fix.

## Testing

Built patched `msys-2.0.dll` from Cygwin 3.6.7 with MSYS2 patches.
Tested on Windows 11 Enterprise with parallel bash spawning from
Claude Code (which fires multiple hook processes per tool invocation).
The crash was occurring consistently before the patch and has not
recurred after installing it.