### PR TITLE
cygcheck: remove an unused variable causing a build error with GCC 16 + zstd CI fix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           msystem: MSYS
           update: true
-          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel xmlto docbook-xsl
+          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel xmlto docbook-xsl libzstd-devel
 
       - name: Build
         shell: msys2 {0}

--- a/winsup/utils/mingw/cygcheck.cc
+++ b/winsup/utils/mingw/cygcheck.cc
@@ -1706,7 +1706,6 @@ dump_sysinfo ()
   else
     {
       char sep = strchr (s, ';') ? ';' : ':';
-      int count_path_items = 0;
       while (1)
 	{
 	  for (e = s; *e && *e != sep; e++);
@@ -1714,7 +1713,6 @@ dump_sysinfo ()
 	    printf ("\t%.*s\n", (int) (e - s), s);
 	  else
 	    puts ("\t.");
-	  count_path_items++;
 	  if (!*e)
 	    break;
 	  s = e + 1;


### PR DESCRIPTION
Since gcc 16 this triggers -Werror=unused-but-set-variable= Remove the unused variable.

```c++
../../../.././winsup/utils/mingw/cygcheck.cc: In function 'void dump_sysinfo()':
../../../.././winsup/utils/mingw/cygcheck.cc:1709:11: error: variable 'count_path_items' set but not used [-Werror=unused-but-set-variable=]
 1709 |       int count_path_items = 0;
      |           ^~~~~~~~~~~~~~~~
```