### PR TITLE
Fix #176. Use the CRT's signal handling on native Win32 processes.

### DIFF
--- a/winsup/cygwin/exceptions.cc
+++ b/winsup/cygwin/exceptions.cc
@@ -1524,6 +1524,7 @@ sigpacket::process ()
   bool issig_wait = false;
   struct sigaction& thissig = global_sigs[si.si_signo];
   void *handler = have_execed ? NULL : (void *) thissig.sa_handler;
+  extern char *pExecedHook;
 
   threadlist_t *tl_entry = NULL;
   _cygtls *tls = NULL;
@@ -1627,6 +1628,54 @@ sigpacket::process ()
     goto exit_sig;
   if (si.si_signo == SIGSTOP)
     goto stop;
+
+/* This is the value the MSVC RT uses for SIGBREAK. MSVC doesn't define
+ * SIGQUIT so we turn it into SIGBREAK, as that seems to be the intent
+ * of the signal. MSVC also sends SIGBREAK to NT Services in response
+ * to CTRL_LOGOFF_EVENTs, which we would consider SIGHUP. Since MSVC
+ * doesn't handle SIGHUP we translate SIGHUP to SIGBREAK as well.
+ */
+#ifndef SIGBREAK
+#define SIGBREAK 21
+#endif
+  /* both of these may be used for SIGABRT */
+#define SIGABRT_22	22
+#define SIGABRT_6	6
+
+  if (pExecedHook)
+    {
+      HANDLE hRemThread;
+      SIZE_T nbytes;
+      int rsig = si.si_signo;
+      switch(rsig)
+	{
+	  case SIGQUIT:
+	  case SIGHUP:
+	    rsig = SIGBREAK;
+	    fallthrough;
+	  case SIGINT:
+	  case SIGTERM:
+	  case SIGBREAK:
+	  case SIGABRT_22:
+	  case SIGABRT_6:
+	  case SIGFPE:
+	  case SIGILL:
+	  case SIGSEGV:
+	    WriteProcessMemory(ch_spawn,pExecedHook,&rsig,sizeof(rsig),&nbytes);
+	    hRemThread = CreateRemoteThread(ch_spawn,NULL,0,
+		      (LPTHREAD_START_ROUTINE)(pExecedHook+sizeof(remote_info1)),
+		      pExecedHook, 0, NULL);
+	    if (hRemThread)
+	      {
+	        WaitForSingleObject(hRemThread,INFINITE);
+		CloseHandle(hRemThread);
+		goto done;
+	      }
+	    fallthrough;
+	  default:
+	    break;
+	}
+    }
 
   if (handler == (void *) SIG_DFL)
     {

--- a/winsup/cygwin/local_includes/sigproc.h
+++ b/winsup/cygwin/local_includes/sigproc.h
@@ -181,3 +181,24 @@ public:
 };
 
 #define myself_nowait ((_pinfo *) myself_nowait_dummy)
+
+extern "C" {
+typedef HMODULE (GetModH_t)(LPCTSTR name);
+typedef FARPROC (GetProc_t)(HMODULE hmod, LPCSTR name);
+typedef int (raise_t)(int sig);
+
+typedef struct remote_info1 {
+  int sig;
+  raise_t *raise;
+} remote_info1;
+
+typedef struct remote_info {
+  int sig;
+  raise_t *raise;
+  GetModH_t *getModH;
+  GetProc_t *getProc;
+  char rname[16];
+  char names[12][16];
+} remote_info;
+
+}

--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -30,6 +30,8 @@ details. */
 #include "ntdll.h"
 #include "shared_info.h"
 
+char *pExecedHook;
+
 /* Add .exe to PROG if not already present and see if that exists.
    If not, return PROG (converted from posix to win32 rules if necessary).
    The result is always BUF.
@@ -277,6 +279,93 @@ child_info_spawn NO_COPY ch_spawn;
 extern "C" void __posix_spawn_sem_release (void *sem, int error);
 
 extern DWORD mutex_timeout; /* defined in fhandler_termios.cc */
+
+extern "C" {
+
+/* Stuff to support propagating signals to native Win32 apps:
+ * Try to find an MSVC runtime DLL attached to the target process.
+ * If found, look for the raise() entry point. Use that to forward
+ * signals that we receive. If we don't find it, cleanup and do
+ * no special signal handling for the target.
+ */
+static remote_info my_rmi = {
+  0, NULL, NULL, NULL,
+  "raise",
+  { "ucrtbase.dll", "msvcrt.dll" }
+};
+
+static DWORD
+remote_hook (remote_info1 *rmi)
+{
+  rmi->raise (rmi->sig);
+  return 0;
+}
+
+static DWORD
+remote_setup (remote_info *rmi)
+{
+  int i;
+  HMODULE hm;
+
+  for (i = 0; rmi->names[i][0]; i++)
+    {
+      hm = rmi->getModH (rmi->names[i]);
+      if (hm)
+	{
+	  rmi->raise = (raise_t *) rmi->getProc (hm, rmi->rname);
+	  if (rmi->raise)
+	    break;
+	}
+    }
+  return 0;
+}
+
+static void
+kill_hook (HANDLE hProc)
+{
+  SIZE_T funcSize = (char *) kill_hook - (char *) remote_setup;
+  SIZE_T fullSize = sizeof (remote_info) + funcSize;
+  SIZE_T nbytes;
+  HMODULE hkernel;
+  HANDLE hRemThread;
+  char *mHook = (char *) VirtualAllocEx (hProc, NULL, fullSize,
+    MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+  syscall_printf("Entering kill_hook, mHook = %p\n", mHook);
+  if (mHook)
+    {
+      hkernel = GetModuleHandle ("kernel32.dll");
+      my_rmi.getModH = (GetModH_t *)GetProcAddress(hkernel, "GetModuleHandleA");
+      my_rmi.getProc = (GetProc_t *)GetProcAddress(hkernel, "GetProcAddress");
+      syscall_printf("getModH %p, getProc %p\n", my_rmi.getModH, my_rmi.getProc);
+      WriteProcessMemory (hProc, mHook, &my_rmi, sizeof(my_rmi), &nbytes);
+      WriteProcessMemory (hProc, mHook+sizeof(my_rmi), (void *)remote_setup,
+        funcSize, &nbytes);
+      hRemThread = CreateRemoteThread (hProc, NULL, 0,
+        (LPTHREAD_START_ROUTINE) (mHook+sizeof(my_rmi)), mHook, 0, NULL);
+      if (hRemThread)
+        {
+          WaitForSingleObject(hRemThread,INFINITE);
+          CloseHandle(hRemThread);
+          ReadProcessMemory(hProc,mHook+sizeof(int),&my_rmi.raise,
+            sizeof(my_rmi.raise), &nbytes);
+          if (my_rmi.raise)
+            {
+	      syscall_printf("myraise %p\n", my_rmi.raise);
+              funcSize = (char *) remote_setup - (char *) remote_hook;
+              WriteProcessMemory (hProc, mHook+sizeof(remote_info1),
+                (void *)remote_hook, funcSize, &nbytes);
+            }
+          else
+            {
+              VirtualFreeEx( hProc, mHook, 0, MEM_RELEASE);
+              mHook = NULL;
+            }
+        }
+      pExecedHook = mHook;
+    }
+}
+}
+
 
 int
 child_info_spawn::worker (const char *prog_arg, const char *const *argv,
@@ -793,6 +882,8 @@ child_info_spawn::worker (const char *prog_arg, const char *const *argv,
 	     process. For Cygwin processes we also have to create a reference
 	     in the child. */
 	  myself.create_winpid_symlink ();
+	  if (!iscygwin())
+	    kill_hook(hExeced);
 	  if (real_path.iscygexec ())
 	    DuplicateHandle (GetCurrentProcess (),
 			     myself.shared_winpid_handle (),


### PR DESCRIPTION
This allows the 7 signals that Microsoft's C runtime supports to be used, instead of only Ctrl-C/SIGINT.

This is just a slightly refreshed version of the patch I wrote for MSYS1 twenty years ago. https://sourceforge.net/p/mingw/bugs/1783/

It only looks for ucrtbase.dll and msvcrt.dll now, and it doesn't worry about 32bit vs 64bit processes since 32bit Windows is long obsolete.