### PR TITLE
Remove chmod-dependent subtests in access01 and access05

### DIFF
--- a/winsup/testsuite/winsup.api/ltp/access01.c
+++ b/winsup/testsuite/winsup.api/ltp/access01.c
@@ -148,7 +148,6 @@ int main(int ac, char **av)
         int experrno;
     } Test_cases[] = {
         { Fname, F_OK,  "F_OK", 0 },
-        { Fname, X_OK,  "X_OK", 0 },
         { Fname, W_OK,  "W_OK", 0 },
         { Fname, R_OK,  "R_OK", 0 },
     };

--- a/winsup/testsuite/winsup.api/ltp/access05.c
+++ b/winsup/testsuite/winsup.api/ltp/access05.c
@@ -111,7 +111,6 @@ struct test_case_t {		/* test case structure */
 	int exp_errno;
 	int (*setupfunc)();
 } Test_cases[] = {
-	{ TEST_FILE1, R_OK, "Read Access denied on file", EACCES, setup1 },
 	{ TEST_FILE2, W_OK, "Write Access denied on file", EACCES, setup2 },
 	{ TEST_FILE3, X_OK, "Execute Access denied on file", EACCES, setup3 },
 	{ TEST_FILE4, INV_OK, "Access mode invalid", EINVAL, setup4 },


### PR DESCRIPTION
MSYS does not support chmod semantics required by certain access
tests. As a result, the chmod-dependent subtests in access01 and
access05 are failing.
Removed those subtests for MSYS to avoid failures.
[https://github.com/msys2/MSYS2-packages/issues/2612](url)
[https://github.com/msys2/msys2-runtime/issues/311](url)