### PR TITLE
fixup! CI: add a GHA for doing a basic build test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: setup-msys2
         uses: msys2/setup-msys2@v2
@@ -33,7 +33,7 @@ jobs:
           make DESTDIR="$(pwd)"/_dest install
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: install
           path: _dest/
@@ -81,7 +81,7 @@ jobs:
           msys2 -c 'pacman --noconfirm -Suu'
 
       - name: Download msys2-runtime artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: install
           path: ${{ steps.msys2.outputs.msys2-location }}


### PR DESCRIPTION
Upgrade GitHub Actions in `build.yaml`: `actions/upload-artifact` from v4 to v7 (the "Upload" step that publishes the just-built `_dest/` install tree as the `install` artifact) and `actions/download-artifact` from v4 to v8 (the "Download msys2-runtime artifact" step in the `msys2-tests` job that overlays that artifact on top of the runner's MSYS2 installation), as well as `checkout` to v7.

These steps invoke the actions with default arguments, so the bumps are behaviorally transparent: they advance the Node.js runtime on the runners and retire the v4 deprecation warnings without altering the upload or download semantics. The asymmetric target versions (upload v7, download v8) simply reflect each action's then-current latest major release.

Originally-authored-by: dependabot[bot] <support@github.com>