### PR TITLE
msys_path_conv: handle leading UTF-8 characters correctly

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -399,7 +399,7 @@ skip_p2w:
     }
     it = *src;
 
-    while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
+    while (!isalnum(*it) && !(0x80 & *it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;
         if (it == end || *it == '\0') return NONE;


### PR DESCRIPTION
When a non-ASCII character is at the beginning of a path, the current conversion destroys the path. This fix will prevent this with an extra check for non-ASCII UTF-8 characters.

This is the last hold-over of Git for Windows' patches that were originally blocking mingw-w64-git from being upstreamed to the MSYS2 project. I believe that this patch is still relevant, even if it is not _required_ to pass Git's test suite.