### PR TITLE
dumper: allow compiling with binutils 2.47

### DIFF
--- a/winsup/utils/dumper.cc
+++ b/winsup/utils/dumper.cc
@@ -827,14 +827,14 @@ dumper::prepare_core_dump ()
       p->section = new_section;
       int section_count = 1;
 
-      bfd_boolean filehdr = 0;
-      bfd_boolean phdrs = 0;
+      bool filehdr = false;
+      bool phdrs = false;
 
       bfd_vma at = 0;
-      bfd_boolean valid_at = 0;
+      bool valid_at = false;
 
       flagword flags = 0;
-      bfd_boolean valid_flags = 1;
+      bool valid_flags = true;
 
       if (p->type == pr_ent_memory)
 	{


### PR DESCRIPTION
In the latest version, binutils' BFD no longer declares a `bfd_boolean`, and the `bfd_record_phdr()` function accepts plain `bool` parameters instead.

Let's accommodate for that to avoid these build failures:

```
  .../winsup/utils/dumper.cc: In member function 'int dumper::prepare_core_dump()':
  .../winsup/utils/dumper.cc:830:7: error: 'bfd_boolean' was not declared in this scope; did you mean 'boolean'?
    830 |       bfd_boolean filehdr = 0;
        |       ^~~~~~~~~~~
        |       boolean
  .../winsup/utils/dumper.cc:831:18: error: expected ';' before 'phdrs'
    831 |       bfd_boolean phdrs = 0;
        |                  ^~~~~~
        |                  ;
  [...]
```